### PR TITLE
[525304] Fix method call in Diagnostic.INFO case (DotJavaValidator.java)

### DIFF
--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/validation/DotJavaValidator.java
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/validation/DotJavaValidator.java
@@ -116,7 +116,7 @@ public class DotJavaValidator extends AbstractDotJavaValidator {
 					break;
 
 				case Diagnostic.INFO:
-					getMessageAcceptor().acceptError(message, attribute, offset,
+					getMessageAcceptor().acceptInfo(message, attribute, offset,
 							length, code, issueData);
 					break;
 


### PR DESCRIPTION
I noticed this working on the recordLabelValidation. I think this is a simple typo. Would be great if you could have a look. Thanks!