### PR TITLE
[454629] Record label attribute validation support for DotEditor

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotValidatorTests.java
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotValidatorTests.java
@@ -9,6 +9,7 @@
  * Contributors:
  *     Tamas Miklossy (itemis AG) - initial implementation (bug #477980)		
  *                                - Add support for polygon-based node shapes (bug #441352)
+ *     Zoey G. Prigge (itemis AG) - Add support for record-based node shapes (bug #454629)
  *
  *******************************************************************************/
 
@@ -24,6 +25,8 @@ import org.eclipse.gef.dot.internal.DotFileUtils;
 import org.eclipse.gef.dot.internal.language.DotInjectorProvider;
 import org.eclipse.gef.dot.internal.language.dot.DotAst;
 import org.eclipse.gef.dot.internal.language.dot.DotPackage;
+import org.eclipse.gef.dot.internal.language.validation.DotRecordLabelJavaValidator;
+import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.junit4.InjectWith;
 import org.eclipse.xtext.junit4.XtextRunner;
 import org.eclipse.xtext.junit4.util.ParseHelper;
@@ -774,6 +777,43 @@ public class DotValidatorTests {
 	public void testRecordShapeLabel() throws Exception {
 		DotAst ast = parse("record_shape_node1.dot");
 		validationTestHelper.assertNoIssues(ast);
+	}
+
+	@Test
+	public void testInvalidPortAssignedSameNameRecordLabel() throws Exception {
+		String text = "digraph{ node [shape=record]; myNode [label=\"<here> foo | <here> more foo\"]; }";
+		DotAst dotAst = parserHelper.parse(text);
+
+		validationTestHelper.assertError(dotAst,
+				DotPackage.eINSTANCE.getAttribute(),
+				DotRecordLabelJavaValidator.PORT_NAME_DUPLICATE, 46, 4,
+				"Semantic error on Attribute label: Port name not unique: here");
+		validationTestHelper.assertError(dotAst,
+				DotPackage.eINSTANCE.getAttribute(),
+				DotRecordLabelJavaValidator.PORT_NAME_DUPLICATE, 59, 4,
+				"Semantic error on Attribute label: Port name not unique: here");
+	}
+
+	@Test
+	public void testInvalidPortNotAssignedNameRecordLabel() throws Exception {
+		String text = "digraph{ node [shape=record]; myNode [label=\"<> foo | <here> more foo\"]; }";
+		DotAst dotAst = parserHelper.parse(text);
+
+		validationTestHelper.assertWarning(dotAst,
+				DotPackage.eINSTANCE.getAttribute(),
+				DotRecordLabelJavaValidator.PORT_NAME_NOT_SET, 45, 6,
+				"Semantic warning on Attribute label: Port unnamed: port cannot be referenced");
+	}
+
+	@Test
+	public void testInvalidSyntaxErrorRecordLabel() throws Exception {
+		String text = "digraph{ node [shape=record]; myNode [label=\"<}> foo | <here> more foo\"]; }";
+		DotAst dotAst = parserHelper.parse(text);
+
+		validationTestHelper.assertError(dotAst,
+				DotPackage.eINSTANCE.getAttribute(),
+				Diagnostic.SYNTAX_DIAGNOSTIC, 46, 1,
+				"Syntax error on Attribute label:", "'}'");
 	}
 
 	private DotAst parse(String fileName) {

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/validation/ConvertingValidationMessageAcceptor.java
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/validation/ConvertingValidationMessageAcceptor.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge  - initial API and implementation (bug #454629)
+ *    
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.language.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.SyntaxErrorMessage;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.validation.ValidationMessageAcceptor;
+
+/**
+ * This class provides a ValidationMessageAcceptor to be used with sub grammars.
+ * It can be used when validating the main grammar to translate validation
+ * errors.
+ * 
+ * @author zgerritprigge
+ *
+ */
+public class ConvertingValidationMessageAcceptor
+		implements ValidationMessageAcceptor {
+
+	private final EObject hostingEObject;
+	private final ValidationMessageAcceptor hostMessageAcceptor;
+	private final String userReadableIdentifier;
+	private final int initialOffset;
+
+	/**
+	 * Constructs a Validation Message acceptor to 'translate' issues while
+	 * validating a sub grammar.
+	 * 
+	 * @param hostingEObject
+	 *            The Object in the main grammar that hosts the sub grammar
+	 * @param hostingFeature
+	 *            Can be null. If set, needs to be unique within hostingEObject
+	 *            (not a list, ...).
+	 * @param userReadableIdentifier
+	 *            A name for the sub grammar understood by the user
+	 * @param hostMessageAcceptor
+	 *            The validationMessageAcceptor of the host grammar
+	 * @param internalOffset
+	 *            Offset from begin of feature
+	 */
+	public ConvertingValidationMessageAcceptor(EObject hostingEObject,
+			EStructuralFeature hostingFeature, String userReadableIdentifier,
+			ValidationMessageAcceptor hostMessageAcceptor, int internalOffset) {
+
+		this.hostingEObject = hostingEObject;
+		this.hostMessageAcceptor = hostMessageAcceptor;
+		this.userReadableIdentifier = userReadableIdentifier;
+
+		this.initialOffset = calculateInitialOffset(hostingFeature,
+				internalOffset);
+	}
+
+	/**
+	 * Helper Method to allow this message acceptor to handle syntax errors
+	 * issued while parsing the sub grammar as validation issues of the main
+	 * grammar.
+	 * 
+	 * @param error
+	 *            Error node from parsing.
+	 */
+	public void acceptSyntaxError(INode error) {
+		SyntaxErrorMessage errorMessage = error.getSyntaxErrorMessage();
+		hostMessageAcceptor.acceptError(
+				buildMessage("Syntax error", errorMessage.getMessage()),
+				hostingEObject, calculateOffset(error.getOffset()),
+				error.getLength(), errorMessage.getIssueCode(),
+				errorMessage.getIssueData());
+	}
+
+	@Override
+	public void acceptError(String message, EObject object,
+			EStructuralFeature feature, int index, String code,
+			String... issueData) {
+		for (INode node : getNodesForEObject(object, feature))
+			hostMessageAcceptor.acceptError(
+					buildMessage("Semantic error", message), hostingEObject,
+					calculateOffset(node.getOffset()), node.getLength(), code,
+					issueData);
+	}
+
+	@Override
+	public void acceptError(String message, EObject object, int offset,
+			int length, String code, String... issueData) {
+		hostMessageAcceptor.acceptError(buildMessage("Semantic error", message),
+				hostingEObject, calculateOffset(offset), length, code,
+				issueData);
+	}
+
+	@Override
+	public void acceptInfo(String message, EObject object,
+			EStructuralFeature feature, int index, String code,
+			String... issueData) {
+		for (INode node : getNodesForEObject(object, feature))
+			hostMessageAcceptor.acceptInfo(
+					buildMessage("Semantic issue info", message),
+					hostingEObject, calculateOffset(node.getOffset()),
+					node.getLength(), code, issueData);
+	}
+
+	@Override
+	public void acceptInfo(String message, EObject object, int offset,
+			int length, String code, String... issueData) {
+		hostMessageAcceptor.acceptInfo(
+				buildMessage("Semantic issue info", message), hostingEObject,
+				calculateOffset(offset), length, code, issueData);
+	}
+
+	@Override
+	public void acceptWarning(String message, EObject object,
+			EStructuralFeature feature, int index, String code,
+			String... issueData) {
+		for (INode node : getNodesForEObject(object, feature))
+			hostMessageAcceptor.acceptWarning(
+					buildMessage("Semantic warning", message), hostingEObject,
+					calculateOffset(node.getOffset()), node.getLength(), code,
+					issueData);
+
+	}
+
+	@Override
+	public void acceptWarning(String message, EObject object, int offset,
+			int length, String code, String... issueData) {
+		hostMessageAcceptor.acceptWarning(
+				buildMessage("Semantic warning", message), hostingEObject,
+				calculateOffset(offset), length, code, issueData);
+	}
+
+	private int calculateInitialOffset(EStructuralFeature hostingFeature,
+			int internalOffset) {
+		List<INode> nodes = getNodesForEObject(hostingEObject, hostingFeature);
+		if (nodes.size() != 1)
+			throw new RuntimeException(
+					"EObject has no node or feature not unique");
+		return nodes.get(0).getOffset() + internalOffset;
+	}
+
+	private int calculateOffset(int offset) {
+		// in theory, initialOffset and offset should always be positive.
+		// but if one is negative, adding them seems useless.
+		// TODO checked if and when and how to handle
+		return offset >= 0 && initialOffset >= 0 ? offset + initialOffset
+				: offset;
+	}
+
+	private List<INode> getNodesForEObject(EObject eObject,
+			EStructuralFeature eStructuralFeature) {
+		List<INode> nodes = NodeModelUtils.findNodesForFeature(eObject,
+				eStructuralFeature);
+		// if the result is empty, possibly the feature is not set
+		// hence we try to find the note for the entire eObject
+		if (nodes.size() == 0) {
+			nodes = new ArrayList<INode>();
+			nodes.add(NodeModelUtils.findActualNodeFor(eObject));
+		}
+		return nodes;
+	}
+
+	private String buildMessage(String errorType, String errorMessage) {
+		StringBuilder message = new StringBuilder();
+		message.append(errorType).append(" on ")
+				.append(hostingEObject.eClass().getName()).append(" ")
+				.append(userReadableIdentifier).append(": ");
+		message.append(errorMessage);
+		String userMessage = message.toString();
+		return userMessage;
+	}
+
+}

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/validation/DotJavaValidator.java
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/validation/DotJavaValidator.java
@@ -12,18 +12,26 @@
  *     Tamas Miklossy  - Add support for arrowType edge decorations (bug #477980)
  *                     - Add support for polygon-based node shapes (bug #441352)
  *                     - Add support for all dot attributes (bug #461506)
+ *     Zoey Gerrit Prigge - Add support for record label attributes (bug #454629)
  *
  *******************************************************************************/
 
 package org.eclipse.gef.dot.internal.language.validation;
 
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.common.reflect.ReflectionUtils;
 import org.eclipse.gef.dot.internal.DotAttributes;
 import org.eclipse.gef.dot.internal.DotAttributes.Context;
 import org.eclipse.gef.dot.internal.language.DotAstHelper;
+import org.eclipse.gef.dot.internal.language.DotRecordLabelStandaloneSetup;
 import org.eclipse.gef.dot.internal.language.dot.AttrList;
 import org.eclipse.gef.dot.internal.language.dot.AttrStmt;
 import org.eclipse.gef.dot.internal.language.dot.Attribute;
@@ -35,13 +43,19 @@ import org.eclipse.gef.dot.internal.language.dot.EdgeRhsSubgraph;
 import org.eclipse.gef.dot.internal.language.dot.GraphType;
 import org.eclipse.gef.dot.internal.language.dot.NodeStmt;
 import org.eclipse.gef.dot.internal.language.shape.PolygonBasedNodeShape;
+import org.eclipse.gef.dot.internal.language.shape.RecordBasedNodeShape;
 import org.eclipse.gef.dot.internal.language.style.NodeStyle;
 import org.eclipse.gef.dot.internal.language.terminals.ID;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.parser.IParser;
+import org.eclipse.xtext.validation.AbstractInjectableValidator;
 import org.eclipse.xtext.validation.Check;
 import org.eclipse.xtext.validation.RangeBasedDiagnostic;
+
+import com.google.inject.Injector;
 
 /**
  * Provides DOT-specific validation rules.
@@ -237,5 +251,60 @@ public class DotJavaValidator extends AbstractDotJavaValidator {
 			error("EdgeOp '->' may only be used in directed graphs.",
 					DotPackage.eINSTANCE.getEdgeRhs_Op());
 		}
+	}
+
+	/**
+	 * Use to run the recordLabel subgrammar validation on relevant labels
+	 * (label attributes on Nodes where a recordBased label shape attribute
+	 * exists).
+	 * 
+	 * @param attribute
+	 *            The attribute to validate.
+	 */
+	@Check
+	public void checkRecordBasedNodeShapeValue(Attribute attribute) {
+		if (DotAttributes.getContext(attribute).equals(Context.NODE)
+				&& attribute.getName().toValue()
+						.equals(DotAttributes.LABEL__GCNE)) {
+			String shapeValue = DotAstHelper.getDependedOnAttributeValue(
+					attribute, DotAttributes.SHAPE__N);
+			if (RecordBasedNodeShape.get(shapeValue) != null) {
+				doRecordLabelValidation(attribute);
+			}
+		}
+	}
+
+	private void doRecordLabelValidation(Attribute attribute) {
+		Injector recordLabelInjector = new DotRecordLabelStandaloneSetup()
+				.createInjectorAndDoEMFRegistration();
+		DotRecordLabelJavaValidator validator = recordLabelInjector
+				.getInstance(DotRecordLabelJavaValidator.class);
+		IParser parser = recordLabelInjector.getInstance(IParser.class);
+
+		ConvertingValidationMessageAcceptor messageAcceptor = new ConvertingValidationMessageAcceptor(
+				attribute, DotPackage.Literals.ATTRIBUTE__VALUE,
+				attribute.getName().toString(), getMessageAcceptor(),
+				"\"".length());
+
+		validator.setMessageAcceptor(messageAcceptor);
+
+		IParseResult result = parser
+				.parse(new StringReader(attribute.getValue().toValue()));
+
+		for (INode error : result.getSyntaxErrors())
+			messageAcceptor.acceptSyntaxError(error);
+
+		Map<Object, Object> validationContext = new HashMap<Object, Object>();
+		validationContext.put(AbstractInjectableValidator.CURRENT_LANGUAGE_NAME,
+				ReflectionUtils.getPrivateFieldValue(validator,
+						"languageName"));
+
+		// validate both the children (loop) and root element
+		Iterator<EObject> iterator = result.getRootASTElement().eAllContents();
+		while (iterator.hasNext())
+			validator.validate(iterator.next(), null/* diagnostic chain */,
+					validationContext);
+
+		validator.validate(result.getRootASTElement(), null, validationContext);
 	}
 }


### PR DESCRIPTION
- Implemented validation methods for the recordLabel in
DotJavaValidator.java
- Introduced ConvertingValidationMessageAcceptor to accept issues in the
scope of the subgrammar and register them in the scope of the Dot
grammar.
- Handling calculating offset in ConvertingValidationMessageAcceptor
- Implemented further validation test cases:
- Tests for other semantic issue (no node returned case) and Syntax
issues added.


Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=454629