### PR TITLE
[491098] Add switch to ignore whitespace in DotExecutableLayoutingTests

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotExecutableLayoutingTests.java
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotExecutableLayoutingTests.java
@@ -7,7 +7,8 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Tamas Miklossy (itemis AG) - initial API and implementation
+ *     Tamas Miklossy     (itemis AG) - initial API and implementation
+ *     Zoey Gerrit Prigge (itemis AG) - added switch to ignore whitespace
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.tests;
@@ -39,6 +40,11 @@ public class DotExecutableLayoutingTests extends AbstractDotExecutableTests {
 		// actual
 		String dotExecutableBuild = "TODO: specify the path to the self-build graphviz dot executable here";
 
+		// whitespace differences in Layout output will be ignored if true
+		// for testing builds from different build-mechanisms
+
+		boolean ignoreWhitespace = false;
+
 		if (!new File(dotExecutableInstalled).exists()
 				|| !new File(dotExecutableBuild).exists()) {
 			// ensure that the tests are only executed if the paths are properly
@@ -49,7 +55,12 @@ public class DotExecutableLayoutingTests extends AbstractDotExecutableTests {
 		String expected = dotLayout(dotExecutableInstalled, name);
 		String actual = dotLayout(dotExecutableBuild, name);
 
-		assertEquals(expected, actual);
+		if (ignoreWhitespace) {
+			assertEquals(expected.replaceAll("\\s+", " "),
+					actual.replaceAll("\\s+", " "));
+		} else {
+			assertEquals(expected, actual);
+		}
 	}
 
 	private String dotLayout(String dotExecutablePath, String fileName) {


### PR DESCRIPTION
- Create the option to ignore whitespace in test, appended this as a
boolean variable to the section of the variables to set the
dot-Executables' locations.
- set the default ignoreWhitespace value to false.

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=491098