### PR TITLE
[534707] Fix visualization of \N,\L,... Escape Sequences in EscStrings

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Tamas Miklossy (itemis AG) - initial API and implementation
+ *     Zoey Gerrit Prigge (itemis AG) - test cases for \E, \T, ... replacement (bug #534707)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.tests
@@ -213,6 +214,22 @@ class Dot2ZestEdgeAttributesConversionTests {
 		'''.assertEdgeLabel("foo\nbar\nbaz")
 	}
 	
+	@Test def edge_label004() {
+		'''
+			digraph {
+				1->2[label="Test \E"]
+			}
+		'''.assertEdgeLabel("Test 1->2")
+	}
+	
+	@Test def edge_label005() {
+		'''
+			digraph samplegraph {
+				1->2[label="\E \G"]
+			}
+		'''.assertEdgeLabel("1->2 samplegraph")
+	}
+	
 	@Test def edge_externalLabel001() {
 		'''
 			digraph {
@@ -235,6 +252,14 @@ class Dot2ZestEdgeAttributesConversionTests {
 				1->2[xlabel="foo\nbar\nbaz"]
 			}
 		'''.assertEdgeExternalLabel("foo\nbar\nbaz")
+	}
+	
+	@Test def edge_externalLabel004() {
+		'''
+			digraph testedGraphName {
+				1->2[xlabel="g: \G e:\E h:\H t:\T"]
+			}
+		'''.assertEdgeExternalLabel("g: testedGraphName e:1->2 h:2 t:1")
 	}
 	
 	@Test def edge_sourceLabel001() {
@@ -260,6 +285,14 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeSourceLabel("foo\nbar\nbaz")
 	}
+	
+	@Test def edge_sourceLabel004() {
+		'''
+			digraph testedGraphName {
+				1->2[taillabel="g: \G e:\E h:\H t:\T"]
+			}
+		'''.assertEdgeSourceLabel("g: testedGraphName e:1->2 h:2 t:1")
+	}
 
 	@Test def edge_targetLabel001() {
 		'''
@@ -283,6 +316,23 @@ class Dot2ZestEdgeAttributesConversionTests {
 				1->2[headlabel="foo\nbar\nbaz"]
 			}
 		'''.assertEdgeTargetLabel("foo\nbar\nbaz")
+	}
+	
+	@Test def edge_targetLabel004() {
+		'''
+			digraph testedGraphName {
+				1->2[headlabel="g: \G e:\E h:\H t:\T"]
+			}
+		'''.assertEdgeTargetLabel("g: testedGraphName e:1->2 h:2 t:1")
+	}
+	
+	@Test def edge_targetLabel005() {
+		//test against null pointer exception
+		'''
+			digraph {
+				1->2[headlabel="\G\L"]
+			}
+		'''.assertEdgeTargetLabel("")
 	}
 	
 	private def assertEdgeStyle(CharSequence dotText, String expected) {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
@@ -198,6 +198,48 @@ class Dot2ZestNodeAttributesConversionTests {
 		'''.assertNodeLabel("a\nb")
 	}
 	
+	@Test def node_label007() {
+			'''
+				digraph {
+					1[label="label \N"]
+				}
+			'''.assertNodeLabel("label 1")
+	}
+	
+	@Test def node_label008() {
+		'''
+			digraph {
+				sample [label="\N"]
+			}
+		'''.assertNodeLabel("sample")
+	}
+	
+	@Test def node_label009() {
+		'''
+			graph mygraph {
+				a[label="graph: \G, node no. \N"]
+			}
+		'''.assertNodeLabel("graph: mygraph, node no. a")
+	}
+	
+	@Test def node_label010() {
+		//test to ascertain no loop is reached 
+		'''
+			graph {
+				a[label="\L"]
+			}
+		'''.assertNodeLabel("\\L")
+	}
+	
+	@Test def node_label011() {
+		//test to ascertain no NPE is reached 
+		'''
+			graph {
+				a[label="\G"]
+			}
+		'''.assertNodeLabel("")
+	}
+	
 	@Test def node_id001() {
 		'''
 			digraph {
@@ -236,6 +278,14 @@ class Dot2ZestNodeAttributesConversionTests {
 				1[xlabel="fantastic label"]
 			}
 		'''.assertNodeXLabel("fantastic label")
+	}
+	
+	@Test def node_xlabel003() { 
+		'''
+			digraph testedGraphName {
+				1[xlabel="node:\L graph:\G"]
+			}
+		'''.assertNodeXLabel("node:1 graph:testedGraphName")
 	}
 	
 	@Test def node_polygonbasedshape001() { 
@@ -545,6 +595,14 @@ class Dot2ZestNodeAttributesConversionTests {
 				1[tooltip="testing\nis\nfun"]
 			}
 		'''.assertNodeTooltip("testing\nis\nfun")
+	}
+	
+	@Test def node_tooltip003() {
+		'''
+			digraph testing{
+				nodename[label="label of \N", tooltip="l:\L n:\N g:\G"]
+			}
+		'''.assertNodeTooltip("l:label of nodename n:nodename g:testing")
 	}
 	
 	private def assertNodeLabelCssStyle(CharSequence dotText, String expected) {


### PR DESCRIPTION
-Fix for all name-replaced esc sequences: \N, \L, \E, \T, \H, \G
-Adapted edge/node convertAttributes methods in
Dot2ZestAttributesConverter
-implemented decodeEscString(String, {Edge, Graph, Node}) methods
-renamed decode(String) to decodeLineBreaks to avoid confusion and moved
to appear en bloc with the other decode... methods.
-moved TODO comment on better decoding of label from
convertAttributes(Node dot, Node zest) to renamed decodeLineBreak method
as the discussion in the corresponding bug report (#508830) is
concerning a more general approach
-removed null check before decodeLineBreak call on node labels due to
default label being set (a null value here would indicate previous code
had been broken - and added to comment).
-added comprehensive tests for use in label, xlabel, sourcelabel,
targetlabel, tooltip


Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=534707