### PR TITLE
[321775] Fixup instance variable visibilty DotHTMLLabelJavaFXNode

### DIFF
--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotHTMLLabelJavaFxNode.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotHTMLLabelJavaFxNode.java
@@ -66,9 +66,9 @@ import javafx.scene.text.Text;
  */
 public class DotHTMLLabelJavaFxNode {
 
-	HtmlLabel root;
+	final private HtmlLabel root;
 
-	DotColorUtil colorUtil = new DotColorUtil();
+	final private DotColorUtil colorUtil = new DotColorUtil();
 
 	/**
 	 * Creates a DotHTMLLabelJavaNode creator


### PR DESCRIPTION
- In DotHTMLLabelJavaFXNode the instance variables "root" and
"colorUtil" are meant to be private and final.

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=321775