### PR TITLE
[321775] Consider node font attributes when rendering HTML-label

### DIFF
--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
@@ -608,7 +608,10 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 			// HTML label is treated as shape only
 			// the surrounding shape is missing here!!!
 			DotHTMLLabelJavaFxNode htmlNode = new DotHTMLLabelJavaFxNode(
-					dotLabel);
+					dotLabel, DotAttributes.getFontname(dot),
+					DotAttributes.getFontsize(dot),
+					DotAttributes.getFontcolor(dot),
+					DotAttributes.getColorscheme(dot));
 			ZestProperties.setShape(zest, htmlNode.getFxElement());
 			// TODO Surround the HTML label with the shape as set above
 


### PR DESCRIPTION
-add a new constructor to DotHTMLLabelJavaFXNode with additional
parameters for node font-face, size and color as well as colorscheme
-adapt DotHTMLLabelJavaFXNode instantiation in
Dot2ZestAttributeConverter
to use new constructor and to hand down node attribute values as
node defaults.
-stop use of Zest CSS stylesheet and include defaultStyle
TagStyleContainer to avoid related layout sizing issues
-adapt DotHTMLLabelJavaFXNode to use node/defaultStyle and implement
colorscheme TODOs

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=321775