### PR TITLE
[321775] Ignore tab/linebreak/... when displaying HTML-like Labels

### DIFF
--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotHTMLLabelJavaFxNode.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotHTMLLabelJavaFxNode.java
@@ -295,13 +295,16 @@ public class DotHTMLLabelJavaFxNode {
 	 */
 	private void handleTextContent(TextFXBuilder builder, HtmlContent content,
 			TagStyleContainer parentStyle) {
-		if (content.getTag() != null)
+		if (content.getTag() != null) {
 			handleTextTag(builder, content.getTag(), parentStyle);
-		else
+		} else {
+			String unescapedText = StringEscapeUtils.unescapeHtml(
+					content.getText().replaceAll("[\\t\\n\\x0B\\f\\r]", "")); //$NON-NLS-1$ //$NON-NLS-2$
 			builder.addFormattedString(new FormattedString(
 					parentStyle != null ? parentStyle
 							: new TagStyleContainer(null, null),
-					StringEscapeUtils.unescapeHtml(content.getText())));
+					unescapedText));
+		}
 	}
 
 	private Pos getPosForBr(HtmlTag brTag) {


### PR DESCRIPTION
Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=321775