### PR TITLE
[540958] Implement labelfontcolor attribute in Dot2ZestAttributeConv.

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
@@ -9,6 +9,7 @@
  * Contributors:
  *     Tamas Miklossy (itemis AG) - initial API and implementation
  *     Zoey Gerrit Prigge (itemis AG) - test cases for \E, \T, ... replacement (bug #534707)
+ *                                    - test cases for labelfontcolor (bug #540958)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.tests
@@ -379,6 +380,28 @@ class Dot2ZestEdgeAttributesConversionTests {
 			-fx-fill: #ff0000;
 		''')
 	}
+	
+	@Test def edge_sourceLabel007() {
+		'''
+			digraph {
+				edge[labelfontcolor=red]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-fill: #ff0000;
+		''')
+	}
+	
+	@Test def edge_sourceLabel008() {
+		'''
+			digraph {
+				edge[labelfontcolor=blue, fontcolor=red]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-fill: #0000ff;
+		''')
+	}
 
 	@Test def edge_targetLabel001() {
 		'''
@@ -439,6 +462,28 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeTargetLabelCssStyle('''
 			-fx-fill: #ff0000;
+		''')
+	}
+	
+	@Test def edge_targetLabel008() {
+		'''
+			digraph {
+				edge[labelfontcolor=red]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-fill: #ff0000;
+		''')
+	}
+	
+	@Test def edge_targetLabel009() {
+		'''
+			digraph {
+				edge[labelfontcolor=blue, fontcolor=red]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-fill: #0000ff;
 		''')
 	}
 

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
@@ -715,7 +715,57 @@ class Dot2ZestGraphCopierTests {
 	}
 
 	@Test def void edge_labelfontcolor() {
-		// TODO: implement
+		// If unset, the fontcolor value is used.
+		'''
+			digraph {
+				1->2[fontcolor="blue", labelfontcolor=red, label="foo", headlabel="baa"]
+				1->3[labelfontcolor=red, headlabel="baa"]
+				2->3[fontcolor="blue", label="foo", headlabel="baa"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node3 {
+					element-label : 3
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Edge1 from Node1 to Node2 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-fill: #ff0000;
+					element-label : foo
+					element-label-css-style : -fx-fill: #0000ff;
+				}
+				Edge2 from Node1 to Node3 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-fill: #ff0000;
+				}
+				Edge3 from Node2 to Node3 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-fill: #0000ff;
+					element-label : foo
+					element-label-css-style : -fx-fill: #0000ff;
+				}
+			}
+		''')
 	}
 
 	@Test def edge_labeltooltip() {

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
@@ -15,6 +15,7 @@
  *     Zoey Gerrit Prigge (itemis AG) - Add support for record-based node shapes (bug #454629)
  *                                    - Add support for HTML labels (bug #321775)
  *                                    - Fix handling of "\N", "\E", "\G" in labels (bug #534707)
+ *                                    - Add support for labelfontcolor attribute (bug #540958)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal.ui;
@@ -130,6 +131,8 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 		}
 
 		String edgeLabelCssStyle = computeZestEdgeLabelCssStyle(dot);
+		String targetSourceLabelCssStyle = computeZestTargetSourceLabelCssStyle(
+				dot);
 
 		String dotLabel = DotAttributes.getLabel(dot);
 		if (dotLabel != null) {
@@ -159,8 +162,9 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 			dotHeadLabel = decodeEscString(dotHeadLabel, dot);
 			dotHeadLabel = decodeLineBreak(dotHeadLabel);
 			ZestProperties.setTargetLabel(zest, dotHeadLabel);
-			if (edgeLabelCssStyle != null) {
-				ZestProperties.setTargetLabelCssStyle(zest, edgeLabelCssStyle);
+			if (targetSourceLabelCssStyle != null) {
+				ZestProperties.setTargetLabelCssStyle(zest,
+						targetSourceLabelCssStyle);
 			}
 		}
 		String dotTailLabel = DotAttributes.getTaillabel(dot);
@@ -168,8 +172,9 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 			dotTailLabel = decodeEscString(dotTailLabel, dot);
 			dotTailLabel = decodeLineBreak(dotTailLabel);
 			ZestProperties.setSourceLabel(zest, dotTailLabel);
-			if (edgeLabelCssStyle != null) {
-				ZestProperties.setSourceLabelCssStyle(zest, edgeLabelCssStyle);
+			if (targetSourceLabelCssStyle != null) {
+				ZestProperties.setSourceLabelCssStyle(zest,
+						targetSourceLabelCssStyle);
 			}
 		}
 
@@ -467,6 +472,22 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 
 	private String computeZestEdgeLabelCssStyle(Edge dot) {
 		Color dotColor = DotAttributes.getFontcolorParsed(dot);
+		if (dotColor != null) {
+			String dotColorScheme = DotAttributes.getColorscheme(dot);
+			String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
+					dotColor);
+			if (javaFxColor != null) {
+				return "-fx-fill: " + javaFxColor + ";"; //$NON-NLS-1$ //$NON-NLS-2$
+			}
+		}
+		return null;
+	}
+
+	private String computeZestTargetSourceLabelCssStyle(Edge dot) {
+		Color dotColor = DotAttributes.getLabelfontcolorParsed(dot);
+		if (dotColor == null) {
+			dotColor = DotAttributes.getFontcolorParsed(dot);
+		}
 		if (dotColor != null) {
 			String dotColorScheme = DotAttributes.getColorscheme(dot);
 			String javaFxColor = colorUtil.computeZestColor(dotColorScheme,


### PR DESCRIPTION
-Use the labelfontcolor attribute for Source/Target label color
-Adapt a new computeZestTargetSourceLabelCssStyle method 
-Implement corresponding Dot2ZestEdgeAttributesConversionTests and
Dot2ZestGraphCopierTests

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=540958