### PR TITLE
[540330] Quickfix to remove redundant attributes

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotQuickfixTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotQuickfixTests.xtend
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Tamas Miklossy (itemis AG) - initial API and implementation
+ *    Zoey G. Prigge (itemis AG) - quickfix to remove redundant attributes (bug #540330)
  *******************************************************************************/
 package org.eclipse.gef.dot.tests
 
@@ -31,6 +32,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 import static org.eclipse.gef.dot.internal.language.validation.DotJavaValidator.INVALID_EDGE_OPERATOR
+import static org.eclipse.gef.dot.internal.language.validation.DotJavaValidator.REDUNDANT_ATTRIBUTE
 
 import static extension org.eclipse.gef.dot.internal.ui.language.editor.DotEditorUtils.getDocument
 import static extension org.junit.Assert.assertEquals
@@ -596,6 +598,30 @@ class DotQuickfixTests {
 			new Quickfix("Replace 'foo' with 'rounded'.",	"Use valid 'rounded' instead of invalid 'foo' graph style.",'''graph{subgraph cluster_0{style="rounded"}}'''),
 			new Quickfix("Replace 'foo' with 'solid'.",		"Use valid 'solid' instead of invalid 'foo' graph style.",	'''graph{subgraph cluster_0{style="solid"}}'''),
 			new Quickfix("Replace 'foo' with 'striped'.",	"Use valid 'striped' instead of invalid 'foo' graph style.",'''graph{subgraph cluster_0{style="striped"}}''')
+		)
+	}
+
+	@Test def redundant_attribute_single() {
+		'''graph{1[label="foo", label="faa"]}'''.testQuickfixesOn(REDUNDANT_ATTRIBUTE,
+			new Quickfix("Remove 'label' attribute.",	"Remove the redundant 'label' attribute.",	'''graph{1[label="faa"]}''')
+		)
+	}
+
+	@Test def redundant_attribute_mixed() {
+		'''graph{1[label="foo", style="rounded", label="faa"]}'''.testQuickfixesOn(REDUNDANT_ATTRIBUTE,
+			new Quickfix("Remove 'label' attribute.", 	"Remove the redundant 'label' attribute.",	'''graph{1[style="rounded", label="faa"]}''')
+		)
+	}
+
+	@Test def redundant_attribute_edge() {
+		'''graph{1--2[style="dotted", style="dashed"]}'''.testQuickfixesOn(REDUNDANT_ATTRIBUTE,
+			new Quickfix("Remove 'style' attribute.",	"Remove the redundant 'style' attribute.",	'''graph{1--2[style="dashed"]}''')
+		)
+	}
+
+	@Test def redundant_attribute_attr_stmt() {
+		'''graph{graph[label="dotted", label="dashed"]1}'''.testQuickfixesOn(REDUNDANT_ATTRIBUTE,
+			new Quickfix("Remove 'label' attribute.",	"Remove the redundant 'label' attribute.",	'''graph{graph[label="dashed"]1}''')
 		)
 	}
 

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/language/quickfix/DotQuickfixProvider.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/language/quickfix/DotQuickfixProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 itemis AG and others.
+ * Copyright (c) 2010, 2018 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -10,14 +10,18 @@
  *     Fabian Steeg    - intial Xtext generation (see bug #277380)
  *     Alexander Nyßen - initial implementation
  *     Tamas Miklossy (itemis AG) - Add quickfix support for all dot attributes (bug #513196)
+ *     Zoey Gerrit Prigge (itemis AG) - quickfix to remove redundant attributes (bug #540330)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal.ui.language.quickfix;
+
+import static org.eclipse.gef.dot.internal.language.validation.DotJavaValidator.REDUNDANT_ATTRIBUTE;
 
 import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.gef.dot.internal.DotAttributes;
 import org.eclipse.gef.dot.internal.language.arrowtype.DeprecatedShape;
 import org.eclipse.gef.dot.internal.language.clustermode.ClusterMode;
@@ -81,6 +85,24 @@ public class DotQuickfixProvider extends DefaultQuickfixProvider {
 						}
 					});
 		}
+	}
+
+	@Fix(REDUNDANT_ATTRIBUTE)
+	public void fixRedundantAttribute(final Issue issue,
+			IssueResolutionAcceptor acceptor) {
+		if (issue.getData() == null || issue.getData().length == 0) {
+			return;
+		}
+
+		String attributeName = issue.getData()[0];
+
+		ISemanticModification semanticModification = (EObject element,
+				IModificationContext context) -> EcoreUtil.remove(element);
+		String label = "Remove '" + attributeName + "' attribute."; //$NON-NLS-1$ //$NON-NLS-2$
+		String description = "Remove the redundant '" + attributeName //$NON-NLS-1$
+				+ "' attribute."; //$NON-NLS-1$
+
+		acceptor.accept(issue, label, description, null, semanticModification);
 	}
 
 	@Fix(DotAttributes.ARROWHEAD__E)


### PR DESCRIPTION
-implement quickfix to remove redundant attributes in
DotQuickfixProvider
-implement corresponding DotQuickfixTests

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=540330