### PR TITLE
[541056] Support (label)fontname/size attributes in DOT Graph View

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
@@ -8,8 +8,7 @@
  *
  * Contributors:
  *     Tamas Miklossy (itemis AG) - initial API and implementation
- *     Zoey Gerrit Prigge (itemis AG) - test cases for \E, \T, ... replacement (bug #534707)
- *                                    - test cases for labelfontcolor (bug #540958)
+ *     Zoey Gerrit Prigge (itemis AG) - additional test cases
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.tests
@@ -275,6 +274,40 @@ class Dot2ZestEdgeAttributesConversionTests {
 		''')
 	}
 
+	@Test def edge_label008() {
+		'''
+			digraph {
+				edge[fontname=Helvetica]
+				1->2[label=l]
+			}
+		'''.assertEdgeLabelCssStyle('''
+			-fx-font-family: "Helvetica";
+		''')
+	}
+
+	@Test def edge_label009() {
+		'''
+			digraph {
+				edge[fontsize=16]
+				1->2[label=l]
+			}
+		'''.assertEdgeLabelCssStyle('''
+			-fx-font-size: 16.0;
+		''')
+	}
+
+	@Test def edge_label010() {
+		'''
+			digraph {
+				1->2[label=l, fontcolor=red, fontname=Helvetica, fontsize=16]
+			}
+		'''.assertEdgeLabelCssStyle('''
+			-fx-fill: #ff0000;
+			-fx-font-family: "Helvetica";
+			-fx-font-size: 16.0;
+		''')
+	}
+
 	@Test def edge_externalLabel001() {
 		'''
 			digraph {
@@ -325,6 +358,41 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeExternalLabelCssStyle('''
 			-fx-fill: #ff0000;
+		''')
+	}
+
+	@Test def edge_externalLabel007() {
+		'''
+			digraph {
+				edge[fontname=Helvetica]
+				1->2[xlabel=x]
+			}
+		'''.assertEdgeExternalLabelCssStyle('''
+			-fx-font-family: "Helvetica";
+		''')
+	}
+
+	@Test def edge_externalLabel008() {
+		'''
+			digraph {
+				edge[fontsize=16]
+				1->2[xlabel=x]
+			}
+		'''.assertEdgeExternalLabelCssStyle('''
+			-fx-font-size: 16.0;
+		''')
+	}
+
+	@Test def edge_externalLabel009() {
+		'''
+			digraph {
+				edge[fontcolor=red, fontname=Helvetica, fontsize=16]
+				1->2[xlabel=x]
+			}
+		'''.assertEdgeExternalLabelCssStyle('''
+			-fx-fill: #ff0000;
+			-fx-font-family: "Helvetica";
+			-fx-font-size: 16.0;
 		''')
 	}
 
@@ -400,6 +468,63 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeSourceLabelCssStyle('''
 			-fx-fill: #0000ff;
+		''')
+	}
+
+	@Test def edge_sourceLabel010() {
+		'''
+			digraph {
+				edge[fontname=Arial]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-font-family: "Arial";
+		''')
+	}
+
+	@Test def edge_sourceLabel011() {
+		'''
+			digraph {
+				edge[labelfontname="Times New Roman", fontname=Arial]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-font-family: "Times New Roman";
+		''')
+	}
+
+	@Test def edge_sourceLabel012() {
+		'''
+			digraph {
+				edge[fontsize=12]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-font-size: 12.0;
+		''')
+	}
+
+	@Test def edge_sourceLabel013() {
+		'''
+			digraph {
+				edge[labelfontsize=14, fontsize=12]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-font-size: 14.0;
+		''')
+	}
+
+	@Test def edge_sourceLabel014() {
+		'''
+			digraph {
+				edge[labelfontsize=14, fontsize=12, fontcolor=green, fontname="Courier New"]
+				1->2[taillabel=t]
+			}
+		'''.assertEdgeSourceLabelCssStyle('''
+			-fx-fill: #00ff00;
+			-fx-font-family: "Courier New";
+			-fx-font-size: 14.0;
 		''')
 	}
 
@@ -484,6 +609,63 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeTargetLabelCssStyle('''
 			-fx-fill: #0000ff;
+		''')
+	}
+
+	@Test def edge_targetLabel010() {
+		'''
+			digraph {
+				edge[fontname=Arial]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-font-family: "Arial";
+		''')
+	}
+
+	@Test def edge_targetLabel011() {
+		'''
+			digraph {
+				edge[labelfontname="Times New Roman", fontname=Arial]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-font-family: "Times New Roman";
+		''')
+	}
+
+	@Test def edge_targetLabel012() {
+		'''
+			digraph {
+				edge[fontsize=12]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-font-size: 12.0;
+		''')
+	}
+
+	@Test def edge_targetLabel013() {
+		'''
+			digraph {
+				edge[labelfontsize=14, fontsize=12]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-font-size: 14.0;
+		''')
+	}
+
+	@Test def edge_targetLabel014() {
+		'''
+			digraph {
+				edge[labelfontsize=14, fontsize=12, fontcolor=green, fontname="Courier New"]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-fill: #00ff00;
+			-fx-font-family: "Courier New";
+			-fx-font-size: 14.0;
 		''')
 	}
 

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
@@ -484,6 +484,62 @@ class Dot2ZestGraphCopierTests {
 		''')
 	}
 
+	@Test def edge_fontname() {
+		'''
+			digraph {
+				1->2[fontname="Comic Sans", label="foo"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Edge1 from Node1 to Node2 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					element-label : foo
+					element-label-css-style : -fx-font-family: "Comic Sans";
+				}
+			}
+		''')
+	}
+
+	@Test def edge_fontsize() {
+		'''
+			digraph {
+				1->2[fontsize=5.5, label="foo"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Edge1 from Node1 to Node2 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					element-label : foo
+					element-label-css-style : -fx-font-size: 5.5;
+				}
+			}
+		''')
+	}
+
 	@Test def edge_headlabel() {
 		'''
 			digraph {
@@ -833,6 +889,114 @@ class Dot2ZestGraphCopierTests {
 					edge-target-label-css-style : -fx-fill: #0000ff;
 					element-label : foo
 					element-label-css-style : -fx-fill: #0000ff;
+				}
+			}
+		''')
+	}
+
+	@Test def edge_labelfontname() {
+		// If unset, the fontcolor value is used.
+		'''
+			digraph {
+				1->2[fontname="Arial", labelfontname="Courier New", label="foo", headlabel="baa"]
+				1->3[labelfontname="Times New Roman", headlabel="baa"]
+				2->3[fontname="Comic Sans", label="foo", headlabel="baa"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node3 {
+					element-label : 3
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Edge1 from Node1 to Node2 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-font-family: "Courier New";
+					element-label : foo
+					element-label-css-style : -fx-font-family: "Arial";
+				}
+				Edge2 from Node1 to Node3 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-font-family: "Times New Roman";
+				}
+				Edge3 from Node2 to Node3 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-font-family: "Comic Sans";
+					element-label : foo
+					element-label-css-style : -fx-font-family: "Comic Sans";
+				}
+			}
+		''')
+	}
+
+	@Test def edge_labelfontsize() {
+		// If unset, the fontcolor value is used.
+		'''
+			digraph {
+				1->2[fontsize=5, labelfontsize=6, label="foo", headlabel="baa"]
+				1->3[labelfontsize=7, headlabel="baa"]
+				2->3[fontsize=8, label="foo", headlabel="baa"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node3 {
+					element-label : 3
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Edge1 from Node1 to Node2 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-font-size: 6.0;
+					element-label : foo
+					element-label-css-style : -fx-font-size: 5.0;
+				}
+				Edge2 from Node1 to Node3 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-font-size: 7.0;
+				}
+				Edge3 from Node2 to Node3 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					edge-target-label : baa
+					edge-target-label-css-style : -fx-font-size: 8.0;
+					element-label : foo
+					element-label-css-style : -fx-font-size: 8.0;
 				}
 			}
 		''')
@@ -1336,6 +1500,42 @@ class Dot2ZestGraphCopierTests {
 		''')
 	}
 
+	@Test def graph_fontname() {
+		// This test shows current behaviour, it needs adaptation once the attribute is supported.
+		'''
+			digraph {
+				graph [label="foo", fontname="Times New Roman"];
+				1
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def graph_fontsize() {
+		// This test shows current behaviour, it needs adaptation once the attribute is supported.
+		'''
+			digraph {
+				graph [label="foo", fontsize=13];
+				1
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+	
 	@Test def graph_forcelabels001() {
 		// This test shows current behaviour, it needs adaptation once the attribute is supported.
 		// The tested graph needs to have very close elements for this attribute to have an effect.
@@ -2297,6 +2497,40 @@ class Dot2ZestGraphCopierTests {
 				Node1 {
 					element-label : 1
 					element-label-css-style : -fx-fill: #00ff00;
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def node_fontname() {
+		'''
+			graph {
+				1[fontname="Helvetica"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					element-label-css-style : -fx-font-family: "Helvetica";
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def node_fontsize() {
+		'''
+			graph {
+				1[fontsize=13]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					element-label-css-style : -fx-font-size: 13.0;
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
@@ -112,6 +112,80 @@ class Dot2ZestNodeAttributesConversionTests {
 		''')
 	}
 
+	@Test def node_fontcolor006() {
+		'''
+			graph {
+				1[xlabel="x", fontcolor="0.482 0.714 0.878"]
+			}
+		'''.assertNodeXLabelCssStyle('''
+			-fx-fill: hsb(173.51999999999998, 71.39999999999999%, 87.8%);
+		''')
+	}
+
+	@Test def node_fontname001() {
+		'''
+			graph {
+				1[fontname=Arial]
+			}
+		'''.assertNodeLabelCssStyle('''
+			-fx-font-family: "Arial";
+		''')
+	}
+
+	@Test def node_fontname002() {
+		'''
+			graph {
+				1[xlabel="x", fontname=Arial]
+			}
+		'''.assertNodeXLabelCssStyle('''
+			-fx-font-family: "Arial";
+		''')
+	}
+
+	@Test def node_fontsize001() {
+		'''
+			graph {
+				1[fontsize="5"]
+			}
+		'''.assertNodeLabelCssStyle('''
+			-fx-font-size: 5.0;
+		''')
+	}
+
+	@Test def node_fontsize002() {
+		'''
+			graph {
+				1[xlabel="x", fontsize="5"]
+			}
+		'''.assertNodeXLabelCssStyle('''
+			-fx-font-size: 5.0;
+		''')
+	}
+
+	@Test def node_fontstyles_combined001() {
+		'''
+			graph {
+				1[fontcolor=red, fontname="Arial", fontsize="3.5"]
+			}
+		'''.assertNodeLabelCssStyle('''
+			-fx-fill: #ff0000;
+			-fx-font-family: "Arial";
+			-fx-font-size: 3.5;
+		''')
+	}
+
+	@Test def node_fontstyles_combined002() {
+		'''
+			graph {
+				1[xlabel="x", fontcolor=red, fontname="Arial", fontsize="3.5"]
+			}
+		'''.assertNodeXLabelCssStyle('''
+			-fx-fill: #ff0000;
+			-fx-font-family: "Arial";
+			-fx-font-size: 3.5;
+		''')
+	}
+
 	@Test def node_height001() {
 		'''
 			digraph {
@@ -631,6 +705,11 @@ class Dot2ZestNodeAttributesConversionTests {
 
 	private def assertNodeLabelCssStyle(CharSequence dotText, String expected) {
 		val actual = dotText.firstNode.convert.labelCssStyle
+		expected.assertEquals(actual.split)
+	}
+	
+	private def assertNodeXLabelCssStyle(CharSequence dotText, String expected) {
+		val actual = dotText.firstNode.convert.externalLabelCssStyle
 		expected.assertEquals(actual.split)
 	}
 

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
@@ -16,6 +16,7 @@
  *                                    - Add support for HTML labels (bug #321775)
  *                                    - Fix handling of "\N", "\E", "\G" in labels (bug #534707)
  *                                    - Add support for labelfontcolor attribute (bug #540958)
+ *                                    - Add support for (label)fontsize/name (bug #541056)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal.ui;
@@ -472,15 +473,10 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 
 	private String computeZestEdgeLabelCssStyle(Edge dot) {
 		Color dotColor = DotAttributes.getFontcolorParsed(dot);
-		if (dotColor != null) {
-			String dotColorScheme = DotAttributes.getColorscheme(dot);
-			String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
-					dotColor);
-			if (javaFxColor != null) {
-				return "-fx-fill: " + javaFxColor + ";"; //$NON-NLS-1$ //$NON-NLS-2$
-			}
-		}
-		return null;
+		String dotColorScheme = DotAttributes.getColorscheme(dot);
+		String dotFont = DotAttributes.getFontname(dot);
+		Double dotSize = DotAttributes.getFontsizeParsed(dot);
+		return computeZestLabelCssStyle(dotColor, dotColorScheme, dotFont, dotSize);
 	}
 
 	private String computeZestTargetSourceLabelCssStyle(Edge dot) {
@@ -488,15 +484,41 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 		if (dotColor == null) {
 			dotColor = DotAttributes.getFontcolorParsed(dot);
 		}
+		String dotColorScheme = DotAttributes.getColorscheme(dot);
+		String dotFont = DotAttributes.getLabelfontname(dot);
+		if (dotFont == null) {
+			dotFont = DotAttributes.getFontname(dot);
+		}
+		Double dotSize = DotAttributes.getLabelfontsizeParsed(dot);
+		if (dotSize == null) {
+			dotSize = DotAttributes.getFontsizeParsed(dot);
+		}
+		return computeZestLabelCssStyle(dotColor, dotColorScheme, dotFont, dotSize);
+	}
+
+	private String computeZestLabelCssStyle(Color dotColor, String dotColorScheme,
+			String dotFont, Double dotSize) {
+		StringBuilder zestStyle = new StringBuilder();
 		if (dotColor != null) {
-			String dotColorScheme = DotAttributes.getColorscheme(dot);
 			String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
 					dotColor);
 			if (javaFxColor != null) {
-				return "-fx-fill: " + javaFxColor + ";"; //$NON-NLS-1$ //$NON-NLS-2$
+				zestStyle.append("-fx-fill: "); //$NON-NLS-1$
+				zestStyle.append(javaFxColor);
+				zestStyle.append(";"); //$NON-NLS-1$
 			}
 		}
-		return null;
+		if (dotFont != null && dotFont.length() > 0) {
+			zestStyle.append("-fx-font-family: \""); //$NON-NLS-1$
+			zestStyle.append(dotFont);
+			zestStyle.append("\";"); //$NON-NLS-1$
+		}
+		if (dotSize != null) {
+			zestStyle.append("-fx-font-size: "); //$NON-NLS-1$
+			zestStyle.append(dotSize);
+			zestStyle.append(";"); //$NON-NLS-1$
+		}
+		return zestStyle.length() > 0 ? zestStyle.toString() : null;
 	}
 
 	protected void convertAttributes(Node dot, Node zest) {
@@ -536,7 +558,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 						.getType() == ID.Type.HTML_STRING
 				: false;
 
-		// label fontcolor
+		// label fontcolor, fontsize, fontname
 		String zestNodeLabelCssStyle = computeZestNodeLabelCssStyle(dot);
 		if (zestNodeLabelCssStyle != null) {
 			ZestProperties.setLabelCssStyle(zest, zestNodeLabelCssStyle);
@@ -654,6 +676,10 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 		if (dotXLabel != null) {
 			dotXLabel = decodeEscString(dotXLabel, dot);
 			ZestProperties.setExternalLabel(zest, dotXLabel);
+			if (zestNodeLabelCssStyle != null) {
+				ZestProperties.setExternalLabelCssStyle(zest,
+						zestNodeLabelCssStyle);
+			}
 		}
 
 		// In case of a record based node shape the label is consumed by the
@@ -824,15 +850,10 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 
 	private String computeZestNodeLabelCssStyle(Node dot) {
 		Color dotColor = DotAttributes.getFontcolorParsed(dot);
-		if (dotColor != null) {
-			String dotColorScheme = DotAttributes.getColorscheme(dot);
-			String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
-					dotColor);
-			if (javaFxColor != null) {
-				return "-fx-fill: " + javaFxColor + ";"; //$NON-NLS-1$ //$NON-NLS-2$
-			}
-		}
-		return null;
+		String dotColorScheme = DotAttributes.getColorscheme(dot);
+		String dotFont = DotAttributes.getFontname(dot);
+		Double dotSize = DotAttributes.getFontsizeParsed(dot);
+		return computeZestLabelCssStyle(dotColor, dotColorScheme, dotFont, dotSize);
 	}
 
 	/**


### PR DESCRIPTION
-Change the computeZestNode/EdgeLabelCssStyle methods in
Dot2ZestAttributesConverter to also include fontname and fontsize
-Change the computeTargetSourceLabelCssStyle method similarly
-Extract new method computeZestLabelCssStyle(dotColor, dotColorScheme,
dotFont, dotSize) to remove duplicate code.

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=541056