### PR TITLE
[NONE] Performance improvements to ZestContentViewer and GraphCopier

### DIFF
--- a/org.eclipse.gef.graph/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.graph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEF Graph
 Bundle-SymbolicName: org.eclipse.gef.graph
-Bundle-Version: 5.0.0.qualifier
+Bundle-Version: 5.1.0.qualifier
 Bundle-Vendor: Eclipse GEF
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gef.graph

--- a/org.eclipse.gef.graph/pom.xml
+++ b/org.eclipse.gef.graph/pom.xml
@@ -21,7 +21,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.graph</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.gef.graph/src/org/eclipse/gef/graph/GraphCopier.java
+++ b/org.eclipse.gef.graph/src/org/eclipse/gef/graph/GraphCopier.java
@@ -12,15 +12,22 @@
  *******************************************************************************/
 package org.eclipse.gef.graph;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.gef.common.attributes.IAttributeCopier;
 import org.eclipse.gef.common.attributes.IAttributeStore;
 
 /**
- * A copier for {@link Graph}s.
+ * A copier for {@link Graph graphs}.
+ *
+ * After a graph was copied, the copier can be queried for the mappings of input
+ * nodes to output nodes and input edges to output edges.
+ *
+ * A copier is a stateful utility.
  *
  * @author anyssen
  *
@@ -35,53 +42,57 @@ public class GraphCopier {
 	 * Creates a new {@link GraphCopier} instance with the given
 	 * {@link IAttributeCopier}.
 	 *
-	 * @param attributeCopier
-	 *            The {@link IAttributeCopier} used to copy the attributes of
-	 *            {@link Graph}, {@link Node}s, and {@link Edge}s.
+	 * @param attributeCopier The {@link IAttributeCopier} used to copy the
+	 *                        attributes of {@link Graph}, {@link Node}s, and
+	 *                        {@link Edge}s.
 	 */
 	public GraphCopier(IAttributeCopier attributeCopier) {
 		this.attributeCopier = attributeCopier;
 	}
 
 	/**
+	 * Discard any data that was tracked in previous copy operations.
+	 *
+	 * @since 5.1
+	 */
+	protected void clearInputToOutputMaps() {
+		inputToOutputNodes.clear();
+		inputToOutputEdges.clear();
+	}
+
+	/**
 	 * Creates a copy of the given {@link Graph}.
 	 *
-	 * @param graph
-	 *            The Graph to copy.
+	 * @param graph The Graph to copy.
 	 * @return A new graph that is the result of the copy operation.
 	 */
 	public Graph copy(Graph graph) {
-		// clear input to output maps
-		inputToOutputNodes.clear();
-		inputToOutputEdges.clear();
+		clearInputToOutputMaps();
 		return copyGraph(graph);
 	}
 
 	/**
 	 * Transfers attributes from the given input {@link Graph}, {@link Node}, or
 	 * {@link Edge} to the given output {@link Graph}, {@link Node}, or
-	 * {@link Edge}. The attributes may be copied or simply transferred. This
-	 * lies within the responsibility of the {@link IAttributeCopier} that was
-	 * passed in on construction of the {@link GraphCopier}.
+	 * {@link Edge}. The attributes may be copied or simply transferred. This lies
+	 * within the responsibility of the {@link IAttributeCopier} that was passed in
+	 * on construction of the {@link GraphCopier}.
 	 *
-	 * @param inputStore
-	 *            The {@link Graph}, {@link Node}, or {@link Edge} from which to
-	 *            copy attributes.
-	 * @param outputStore
-	 *            The {@link Graph}, {@link Node}, or {@link Edge} to copy
-	 *            attributes to.
+	 * @param inputStore  The {@link Graph}, {@link Node}, or {@link Edge} from
+	 *                    which to copy attributes.
+	 * @param outputStore The {@link Graph}, {@link Node}, or {@link Edge} to copy
+	 *                    attributes to.
 	 */
 	// TODO: This callback should be removed (inlined); we will need to refactor
 	// the Dot2ZestGraphConverter first into a pure IAttributeCopier.
 	protected void copyAttributes(IAttributeStore inputStore, IAttributeStore outputStore) {
-		attributeCopier.copy(inputStore, outputStore);
+		getAttributeCopier().copy(inputStore, outputStore);
 	}
 
 	/**
 	 * Creates a copy of the given edge.
 	 *
-	 * @param edge
-	 *            The Edge to copy.
+	 * @param edge The Edge to copy.
 	 * @return A new {@link Edge} with transferred relations and (copied)
 	 *         attributes.
 	 */
@@ -96,44 +107,45 @@ public class GraphCopier {
 	}
 
 	/**
-	 * Copies the given {@link Graph} using the current
-	 * {@link IAttributeCopier}. Records the copied nodes in the
-	 * {@link #getInputToOutputNodeMap()} and the copied edges in the
-	 * {@link #getInputToOutputEdgeMap()}.
+	 * Copies all the edges of the given graph into the output graph.
 	 *
-	 * @param graph
-	 *            The input {@link Graph} to copy.
-	 * @return The copied result {@link Graph}.
+	 * @param graph       The input {@link Graph} to copy.
+	 * @param outputGraph The output Graph.
+	 *
+	 * @since 5.1
 	 */
-	protected Graph copyGraph(Graph graph) {
-		// create new graph to hold the copy
-		Graph outputGraph = new Graph();
-		copyAttributes(graph, outputGraph);
-		// copy nodes, keeping track of copied nodes (so we can relocate them to
-		// link edges)
-		for (Node inputNode : graph.getNodes()) {
-			Node outputNode = copyNode(inputNode);
-			if (outputNode != null) {
-				inputToOutputNodes.put(inputNode, outputNode);
-				outputGraph.getNodes().add(outputNode);
-			}
-		}
-		// copy edges
+	protected void copyEdges(Graph graph, Graph outputGraph) {
+		List<Edge> allEdges = new ArrayList<>(graph.getEdges().size());
 		for (Edge inputEdge : graph.getEdges()) {
 			Edge outputEdge = copyEdge(inputEdge);
 			if (outputEdge != null) {
-				inputToOutputEdges.put(inputEdge, outputEdge);
-				outputGraph.getEdges().add(outputEdge);
+				trackCopiedEdge(inputEdge, outputEdge);
+				allEdges.add(outputEdge);
 			}
 		}
+		outputGraph.getEdges().addAll(allEdges);
+	}
+
+	/**
+	 * Copies the given {@link Graph} using the current {@link IAttributeCopier}.
+	 * Records the copied nodes in the {@link #getInputToOutputNodeMap()} and the
+	 * copied edges in the {@link #getInputToOutputEdgeMap()}.
+	 *
+	 * @param graph The input {@link Graph} to copy.
+	 * @return The copied result {@link Graph}.
+	 */
+	protected Graph copyGraph(Graph graph) {
+		Graph outputGraph = new Graph();
+		copyAttributes(graph, outputGraph);
+		copyNodes(graph, outputGraph);
+		copyEdges(graph, outputGraph);
 		return outputGraph;
 	}
 
 	/**
 	 * Creates a copy of the given node.
 	 *
-	 * @param node
-	 *            The {@link Node} to copy.
+	 * @param node The {@link Node} to copy.
 	 * @return A new Node with transferred relations and (copied) attributes.
 	 */
 	protected Node copyNode(Node node) {
@@ -145,6 +157,27 @@ public class GraphCopier {
 			outputNode.setNestedGraph(nested);
 		}
 		return outputNode;
+	}
+
+	/**
+	 * Copies all the nodes of the given graph into the output graph.
+	 *
+	 * @param graph       The input {@link Graph} to copy.
+	 * @param outputGraph The output Graph.
+	 * @since 5.1
+	 */
+	protected void copyNodes(Graph graph, Graph outputGraph) {
+		// keeping track of copied nodes (so we can relocate them to
+		// link edges)
+		List<Node> allNodes = new ArrayList<>(graph.getNodes().size());
+		for (Node inputNode : graph.getNodes()) {
+			Node outputNode = copyNode(inputNode);
+			if (outputNode != null) {
+				trackCopiedNode(inputNode, outputNode);
+				allNodes.add(outputNode);
+			}
+		}
+		outputGraph.getNodes().addAll(allNodes);
 	}
 
 	/**
@@ -176,6 +209,30 @@ public class GraphCopier {
 	 */
 	public Map<Node, Node> getInputToOutputNodeMap() {
 		return Collections.unmodifiableMap(inputToOutputNodes);
+	}
+
+	/**
+	 * Maintains a mapping from the input edge to the output edge.
+	 *
+	 * @param inputEdge  the input edge.
+	 * @param outputEdge the output edge.
+	 *
+	 * @since 5.1
+	 */
+	protected void trackCopiedEdge(Edge inputEdge, Edge outputEdge) {
+		inputToOutputEdges.put(inputEdge, outputEdge);
+	}
+
+	/**
+	 * Maintains a mapping from the input node to the output node.
+	 *
+	 * @param inputNode  the input node.
+	 * @param outputNode the output node.
+	 *
+	 * @since 5.1
+	 */
+	protected void trackCopiedNode(Node inputNode, Node outputNode) {
+		inputToOutputNodes.put(inputNode, outputNode);
 	}
 
 }

--- a/org.eclipse.gef.mvc.fx/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.mvc.fx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEF MVC.FX
 Bundle-SymbolicName: org.eclipse.gef.mvc.fx
-Bundle-Version: 5.0.2.qualifier
+Bundle-Version: 5.0.3.qualifier
 Bundle-Vendor: Eclipse GEF
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gef.mvc.fx;uses:="com.google.inject.multibindings",

--- a/org.eclipse.gef.mvc.fx/pom.xml
+++ b/org.eclipse.gef.mvc.fx/pom.xml
@@ -21,6 +21,6 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.mvc.fx</artifactId>
-	<version>5.0.2-SNAPSHOT</version>
+	<version>5.0.3-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.gef.zest.fx.jface/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.zest.fx.jface/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEF Zest.FX.JFace
 Bundle-SymbolicName: org.eclipse.gef.zest.fx.jface;singleton:=true
-Bundle-Version: 5.0.2.qualifier
+Bundle-Version: 5.1.0.qualifier
 Bundle-Vendor: Eclipse GEF
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gef.zest.fx.jface;uses:="com.google.inject"

--- a/org.eclipse.gef.zest.fx.jface/pom.xml
+++ b/org.eclipse.gef.zest.fx.jface/pom.xml
@@ -21,6 +21,6 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.zest.fx.jface</artifactId>
-	<version>5.0.2-SNAPSHOT</version>
+	<version>5.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.gef.zest.fx.jface/src/org/eclipse/gef/zest/fx/jface/ZestContentViewer.java
+++ b/org.eclipse.gef.zest.fx.jface/src/org/eclipse/gef/zest/fx/jface/ZestContentViewer.java
@@ -84,14 +84,12 @@ public class ZestContentViewer extends ContentViewer {
 	private Map<Object, Node> contentNodeMap = new IdentityHashMap<>();
 
 	/**
-	 * Constructs a new {@link ZestContentViewer}. The given {@link Module} is
-	 * saved so that it can be later used to create an {@link Injector} that is
-	 * later used for the injection of members and the construction of the
-	 * {@link IDomain}.
+	 * Constructs a new {@link ZestContentViewer}. The given {@link Module} is saved
+	 * so that it can be later used to create an {@link Injector} that is later used
+	 * for the injection of members and the construction of the {@link IDomain}.
 	 *
-	 * @param module
-	 *            The {@link Module} from which an {@link Injector} is created
-	 *            later.
+	 * @param module The {@link Module} from which an {@link Injector} is created
+	 *               later.
 	 */
 	public ZestContentViewer(Module module) {
 		injector = Guice.createInjector(module);
@@ -103,10 +101,8 @@ public class ZestContentViewer extends ContentViewer {
 	 * {@link Composite}. The {@link FXCanvas} serves acs the container for the
 	 * JavaFX {@link Scene} which renders the contents.
 	 *
-	 * @param parent
-	 *            The parent {@link Composite}.
-	 * @param style
-	 *            The SWT style bits to be used for the to be created canvas.
+	 * @param parent The parent {@link Composite}.
+	 * @param style  The SWT style bits to be used for the to be created canvas.
 	 * @return An {@link FXCanvas} inside of the given <i>parent</i>.
 	 */
 	protected FXCanvas createCanvas(final Composite parent, int style) {
@@ -115,14 +111,12 @@ public class ZestContentViewer extends ContentViewer {
 	}
 
 	/**
-	 * Creates the control for this {@link ZestContentViewer} inside of the
-	 * given <i>parent</i> {@link Composite}.
+	 * Creates the control for this {@link ZestContentViewer} inside of the given
+	 * <i>parent</i> {@link Composite}.
 	 *
-	 * @param parent
-	 *            The parent {@link Composite}.
-	 * @param style
-	 *            The SWT style for this {@link ZestContentViewer}, which will
-	 *            be forwarded to its {@link FXCanvas} control.
+	 * @param parent The parent {@link Composite}.
+	 * @param style  The SWT style for this {@link ZestContentViewer}, which will be
+	 *               forwarded to its {@link FXCanvas} control.
 	 */
 	public void createControl(Composite parent, int style) {
 		// create viewer and canvas only after toolkit has been initialized
@@ -144,21 +138,21 @@ public class ZestContentViewer extends ContentViewer {
 	/**
 	 * Constructs and returns a new {@link Edge} connecting the given
 	 * <i>sourceNode</i> and <i>targetNode</i>. If the <i>labelProvider</i>
-	 * implements {@link IGraphAttributesProvider}, then attributes for the edge
-	 * are determined using the
-	 * {@link IGraphAttributesProvider#getEdgeAttributes(Object, Object)}
-	 * methods and inserted into the edge.
+	 * implements {@link IGraphAttributesProvider}, then attributes for the edge are
+	 * determined using the
+	 * {@link IGraphAttributesProvider#getEdgeAttributes(Object, Object)} methods
+	 * and inserted into the edge.
 	 *
-	 * @param labelProvider
-	 *            This viewer's {@link ILabelProvider} for convenience.
-	 * @param contentSourceNode
-	 *            The content element representing the source node of this edge.
-	 * @param sourceNode
-	 *            The already created source {@link Node} of this edge.
-	 * @param contentTargetNode
-	 *            The content element representing the target node of this edge.
-	 * @param targetNode
-	 *            The already created target {@link Node} of this edge.
+	 * @param labelProvider     This viewer's {@link ILabelProvider} for
+	 *                          convenience.
+	 * @param contentSourceNode The content element representing the source node of
+	 *                          this edge.
+	 * @param sourceNode        The already created source {@link Node} of this
+	 *                          edge.
+	 * @param contentTargetNode The content element representing the target node of
+	 *                          this edge.
+	 * @param targetNode        The already created target {@link Node} of this
+	 *                          edge.
 	 * @return The new {@link Edge}.
 	 */
 	protected Edge createEdge(ILabelProvider labelProvider, Object contentSourceNode, Node sourceNode,
@@ -196,12 +190,12 @@ public class ZestContentViewer extends ContentViewer {
 	 * Creates a {@link Graph} nested in the node represented by the given
 	 * <i>contentNestingNode</i>.
 	 *
-	 * @param contentNestingNode
-	 *            The content {@link Object} that represents the nesting node.
-	 * @param graphContentProvider
-	 *            This viewer's {@link IGraphContentProvider} for convenience.
-	 * @param labelProvider
-	 *            This viewer's {@link ILabelProvider} for convenience.
+	 * @param contentNestingNode   The content {@link Object} that represents the
+	 *                             nesting node.
+	 * @param graphContentProvider This viewer's {@link IGraphContentProvider} for
+	 *                             convenience.
+	 * @param labelProvider        This viewer's {@link ILabelProvider} for
+	 *                             convenience.
 	 * @return The new {@link Graph}.
 	 */
 	protected Graph createNestedGraph(Object contentNestingNode, IGraphContentProvider graphContentProvider,
@@ -224,15 +218,15 @@ public class ZestContentViewer extends ContentViewer {
 
 	/**
 	 * Creates a {@link Node} for the specified <i>contentNode</i> using the
-	 * {@link IContentProvider} and {@link ILabelProvider}. Moreover, the new
-	 * node is put into the given <i>contentToGraphMap</i>.
+	 * {@link IContentProvider} and {@link ILabelProvider}. Moreover, the new node
+	 * is put into the given <i>contentToGraphMap</i>.
 	 *
-	 * @param contentNode
-	 *            The content {@link Object} that represents the node.
-	 * @param graphContentProvider
-	 *            This viewer's {@link IGraphContentProvider} for convenience.
-	 * @param labelProvider
-	 *            This viewer's {@link ILabelProvider} for convenience.
+	 * @param contentNode          The content {@link Object} that represents the
+	 *                             node.
+	 * @param graphContentProvider This viewer's {@link IGraphContentProvider} for
+	 *                             convenience.
+	 * @param labelProvider        This viewer's {@link ILabelProvider} for
+	 *                             convenience.
 	 * @return The new {@link Node}.
 	 */
 	protected Node createNode(final Object contentNode, IGraphContentProvider graphContentProvider,
@@ -337,27 +331,30 @@ public class ZestContentViewer extends ContentViewer {
 	}
 
 	/**
-	 * Creates graph {@link Node nodes} and {@link Edge edges} from the given
-	 * array of <i>contentNodes</i>.
+	 * Creates graph {@link Node nodes} and {@link Edge edges} from the given array
+	 * of <i>contentNodes</i>.
 	 *
-	 * @param graphContentProvider
-	 *            This viewer's {@link IGraphContentProvider} for convenience.
-	 * @param labelProvider
-	 *            This viewer's {@link ILabelProvider} for convenience.
-	 * @param graph
-	 *            The {@link Graph} for which nodes and edges are created.
-	 * @param contentNodes
-	 *            Content elements which represent nodes that are to be created
-	 *            together with the edges between them.
+	 * @param graphContentProvider This viewer's {@link IGraphContentProvider} for
+	 *                             convenience.
+	 * @param labelProvider        This viewer's {@link ILabelProvider} for
+	 *                             convenience.
+	 * @param graph                The {@link Graph} for which nodes and edges are
+	 *                             created.
+	 * @param contentNodes         Content elements which represent nodes that are
+	 *                             to be created together with the edges between
+	 *                             them.
 	 */
 	protected void createNodesAndEdges(IGraphContentProvider graphContentProvider, ILabelProvider labelProvider,
 			Graph graph, Object[] contentNodes) {
 		// create nodes
+		List<Node> allNodes = new ArrayList<>();
 		for (Object node : contentNodes) {
 			Node graphNode = createNode(node, graphContentProvider, labelProvider);
-			graph.getNodes().add(graphNode);
+			allNodes.add(graphNode);
 		}
+		graph.getNodes().addAll(allNodes);
 		// create edges
+		List<Edge> allEdges = new ArrayList<>();
 		for (Object contentSourceNode : contentNodes) {
 			Node sourceNode = contentNodeMap.get(contentSourceNode);
 			Object[] connectedTo = graphContentProvider.getAdjacentNodes(contentSourceNode);
@@ -365,22 +362,20 @@ public class ZestContentViewer extends ContentViewer {
 				for (Object contentTargetNode : connectedTo) {
 					Node targetNode = contentNodeMap.get(contentTargetNode);
 					Edge edge = createEdge(labelProvider, contentSourceNode, sourceNode, contentTargetNode, targetNode);
-					graph.getEdges().add(edge);
+					allEdges.add(edge);
 				}
 			}
 		}
+		graph.getEdges().addAll(allEdges);
 	}
 
 	/**
-	 * Creates a complete {@link Graph} using the given {@link IContentProvider}
-	 * and {@link ILabelProvider}.
+	 * Creates a complete {@link Graph} using the given {@link IContentProvider} and
+	 * {@link ILabelProvider}.
 	 *
-	 * @param contentProvider
-	 *            The {@link IContentProvider} for this viewer.
-	 * @param labelProvider
-	 *            The {@link ILabelProvider} for this viewer.
-	 * @return A complete {@link Graph} constructed by using the given
-	 *         providers.
+	 * @param contentProvider The {@link IContentProvider} for this viewer.
+	 * @param labelProvider   The {@link ILabelProvider} for this viewer.
+	 * @return A complete {@link Graph} constructed by using the given providers.
 	 */
 	protected Graph createRootGraph(IContentProvider contentProvider, ILabelProvider labelProvider) {
 		Graph graph = createEmptyGraph();
@@ -490,11 +485,10 @@ public class ZestContentViewer extends ContentViewer {
 	}
 
 	/**
-	 * Changes the {@link ILayoutAlgorithm} that is used for laying out the
-	 * contents to the given value.
+	 * Changes the {@link ILayoutAlgorithm} that is used for laying out the contents
+	 * to the given value.
 	 *
-	 * @param layoutAlgorithm
-	 *            The new {@link ILayoutAlgorithm} to use.
+	 * @param layoutAlgorithm The new {@link ILayoutAlgorithm} to use.
 	 */
 	public void setLayoutAlgorithm(ILayoutAlgorithm layoutAlgorithm) {
 		this.layoutAlgorithm = layoutAlgorithm;
@@ -534,8 +528,7 @@ public class ZestContentViewer extends ContentViewer {
 	 * Converts the given {@link Color} into a CSS string:
 	 * <code>"rgb(red,green,blue)"</code>.
 	 *
-	 * @param color
-	 *            The {@link Color} to convert.
+	 * @param color The {@link Color} to convert.
 	 * @return The corresponding CSS string.
 	 */
 	protected String toCssRgb(Color color) {

--- a/org.eclipse.gef.zest.fx/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.zest.fx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEF Zest.FX
 Bundle-SymbolicName: org.eclipse.gef.zest.fx
-Bundle-Version: 5.0.1.qualifier
+Bundle-Version: 5.1.0.qualifier
 Bundle-Vendor: Eclipse GEF
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gef.zest.fx;uses:="com.google.inject,com.google.inject.multibindings",

--- a/org.eclipse.gef.zest.fx/pom.xml
+++ b/org.eclipse.gef.zest.fx/pom.xml
@@ -21,6 +21,6 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.zest.fx</artifactId>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/parts/ZestFxContentPartFactory.java
+++ b/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/parts/ZestFxContentPartFactory.java
@@ -66,4 +66,16 @@ public class ZestFxContentPartFactory implements IContentPartFactory {
 		return part;
 	}
 
+	/**
+	 * Access to the injector that is used to initialize the result objects of
+	 * {@link #createContentPart(Object, Map)}.
+	 *
+	 * @return the injector.
+	 *
+	 * @since 5.1
+	 */
+	protected Injector getInjector() {
+		return injector;
+	}
+
 }


### PR DESCRIPTION
Make use of bulk operations to reduce the number of fired events.

More details in the individual commit messages of each commit.