### PR TITLE
[542663] Increase timeout for FontName parser generation in Dot mwe2

### DIFF
--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/GenerateDot.mwe2
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/GenerateDot.mwe2
@@ -436,8 +436,11 @@ Workflow {
 
 			// The antlr parser generator fragment
 			fragment = org.eclipse.xtext.generator.parser.antlr.ex.rt.AntlrGeneratorFragment auto-inject {
+				antlrParam = "-Xconversiontimeout"
+				antlrParam = "10000"
 				options = {
 					ignoreCase = true
+					classSplitting = true
 				}
 			}
 
@@ -446,8 +449,11 @@ Workflow {
 
 			// generates a more lightweight Antlr parser and lexer tailored for content assist (for case-insensitive keywords)
 			fragment = parser.antlr.ex.ca.ContentAssistParserGeneratorFragment auto-inject {
+				antlrParam = "-Xconversiontimeout"
+				antlrParam = "10000"
 				options = {
 					ignoreCase = true
+					classSplitting = true
 				}
 			}
 


### PR DESCRIPTION
-Try to avoid build error in Jenkins

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=542663