### PR TITLE
[461506] Add penwidth attribute support

### DIFF
--- a/org.eclipse.gef.dot.tests/resources/penwidth.dot
+++ b/org.eclipse.gef.dot.tests/resources/penwidth.dot
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *       Zoey Gerrit Prigge (itemis AG) - Initial text
+ *
+ *******************************************************************************/
+ 
+digraph {
+	subgraph clusterName {
+		graph [penwidth=2];
+		1
+	}
+	edge[penwidth=1.5]
+	node[penwidth=1.5]
+	
+	2
+	3 [penwidth=12]
+	
+	2->3
+	3->4
+	5->6[penwidth=1.5]
+}

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotAttributesTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotAttributesTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG and others.
+ * Copyright (c) 2016, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -876,6 +876,45 @@ class DotAttributesTests {
 		"1--2".assertEquals(e._getName)
 	}
 
+	@Test def edge_penwidth() {
+		val n1 = new Node.Builder().buildNode
+		val n2 = new Node.Builder().buildNode
+		val it = new Edge.Builder(n1, n2).buildEdge
+		
+		// test getters if no explicit value is set
+		penwidthRaw.assertNull
+		penwidth.assertNull
+		penwidthParsed.assertNull
+		
+		// set valid string values
+		var validPenwidth = "22.5"
+		penwidth = validPenwidth
+		validPenwidth.assertEquals(penwidth)
+		
+		// set valid parsed values
+		var validPenwidthParsed = new Double(5)
+		penwidthParsed = validPenwidthParsed
+		validPenwidthParsed.assertEquals(penwidthParsed)
+		
+		// set minimum parsed values
+		validPenwidthParsed = new Double(0.0)
+		penwidthParsed = validPenwidthParsed
+		validPenwidthParsed.assertEquals(penwidthParsed)
+		
+		// set syntactically invalid values
+		invalidValue([penwidth = "2,5"],
+			"Cannot set edge attribute 'penwidth' to '2,5'. The value '2,5' is not a syntactically correct double: For input string: \"2,5\"."
+		)
+		invalidValue([penwidth = "foo"],
+			"Cannot set edge attribute 'penwidth' to 'foo'. The value 'foo' is not a syntactically correct double: For input string: \"foo\"."
+		)
+
+		// set syntactically correct, but semantically invalid values
+		invalidValue([penwidth = "-0.5"],
+			"Cannot set edge attribute 'penwidth' to '-0.5'. The double value '-0.5' is not semantically correct: Value may not be smaller than 0.0."
+		)
+	}
+
 	@Test def edge_pos() {
 		val n1 = new Node.Builder().buildNode
 		val n2 = new Node.Builder().buildNode
@@ -1603,6 +1642,43 @@ class DotAttributesTests {
 		// set syntactically correct, but semantically invalid values
 		invalidValue([fontsize = "0.5"],
 			"Cannot set graph attribute 'fontsize' to '0.5'. The double value '0.5' is not semantically correct: Value may not be smaller than 1.0."
+		)
+	}
+
+	@Test def cluster_penwidth() {
+		val it = new Graph.Builder().build
+		
+		// test getters if no explicit value is set
+		penwidthRaw.assertNull
+		penwidth.assertNull
+		penwidthParsed.assertNull
+		
+		// set valid string values
+		var validPenwidth = "22.5"
+		penwidth = validPenwidth
+		validPenwidth.assertEquals(validPenwidth)
+		
+		// set valid parsed values
+		var validPenwidthParsed = new Double(5)
+		penwidthParsed = validPenwidthParsed
+		validPenwidthParsed.assertEquals(validPenwidthParsed)
+		
+		// set minimum parsed values
+		validPenwidthParsed = new Double(0.0)
+		penwidthParsed = validPenwidthParsed
+		validPenwidthParsed.assertEquals(validPenwidthParsed)
+		
+		// set syntactically invalid values
+		invalidValue([penwidth = "2,5"],
+			"Cannot set graph attribute 'penwidth' to '2,5'. The value '2,5' is not a syntactically correct double: For input string: \"2,5\"."
+		)
+		invalidValue([penwidth = "foo"],
+			"Cannot set graph attribute 'penwidth' to 'foo'. The value 'foo' is not a syntactically correct double: For input string: \"foo\"."
+		)
+
+		// set syntactically correct, but semantically invalid values
+		invalidValue([penwidth = "-0.5"],
+			"Cannot set graph attribute 'penwidth' to '-0.5'. The double value '-0.5' is not semantically correct: Value may not be smaller than 0.0."
 		)
 	}
 
@@ -2690,6 +2766,43 @@ class DotAttributesTests {
 		_setName("TestNode")
 		"TestNode".assertEquals(_getName)
 		ID.fromString("TestNode").assertEquals(_getNameRaw)
+	}
+
+	@Test def node_penwidth() {
+		val it = new Node.Builder().buildNode
+		
+		// test getters if no explicit value is set
+		penwidthRaw.assertNull
+		penwidth.assertNull
+		penwidthParsed.assertNull
+		
+		// set valid string values
+		var validPenwidth = "22.5"
+		penwidth = validPenwidth
+		validPenwidth.assertEquals(validPenwidth)
+		
+		// set valid parsed values
+		var validPenwidthParsed = new Double(5)
+		penwidthParsed = validPenwidthParsed
+		validPenwidthParsed.assertEquals(validPenwidthParsed)
+		
+		// set minimum parsed values
+		validPenwidthParsed = new Double(0.0)
+		penwidthParsed = validPenwidthParsed
+		validPenwidthParsed.assertEquals(validPenwidthParsed)
+		
+		// set syntactically invalid values
+		invalidValue([penwidth = "2,5"],
+			"Cannot set node attribute 'penwidth' to '2,5'. The value '2,5' is not a syntactically correct double: For input string: \"2,5\"."
+		)
+		invalidValue([penwidth = "foo"],
+			"Cannot set node attribute 'penwidth' to 'foo'. The value 'foo' is not a syntactically correct double: For input string: \"foo\"."
+		)
+
+		// set syntactically correct, but semantically invalid values
+		invalidValue([penwidth = "-0.5"],
+			"Cannot set node attribute 'penwidth' to '-0.5'. The double value '-0.5' is not semantically correct: Value may not be smaller than 0.0."
+		)
 	}
 
 	@Test def node_pos() {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotContentAssistTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotContentAssistTests.xtend
@@ -268,8 +268,8 @@ class DotContentAssistTests extends AbstractContentAssistTest {
 			}
 		'''.testContentAssistant(#["]", "arrowhead", "arrowsize", "arrowtail", "color", "colorscheme",
 			"dir", "edgetooltip", "fillcolor", "fontcolor", "fontname", "fontsize", "headlabel", "headport", "headtooltip",
-			"head_lp", "id", "label", "labelfontcolor", "labelfontname", "labelfontsize", "labeltooltip", "lp", "pos", "style",
-			"taillabel", "tailport", "tailtooltip", "tail_lp", "tooltip", "xlabel", "xlp"
+			"head_lp", "id", "label", "labelfontcolor", "labelfontname", "labelfontsize", "labeltooltip", "lp", "penwidth", "pos", 
+			"style", "taillabel", "tailport", "tailtooltip", "tail_lp", "tooltip", "xlabel", "xlp"
 		], "arrowhead", '''
 			graph {
 				edge[arrowhead=]
@@ -283,8 +283,8 @@ class DotContentAssistTests extends AbstractContentAssistTest {
 			}
 		'''.testContentAssistant(#["]", "arrowhead", "arrowsize", "arrowtail", "color", "colorscheme",
 			"dir", "edgetooltip", "fillcolor", "fontcolor", "fontname", "fontsize", "headlabel", "headport", "headtooltip",
-			"head_lp", "id", "label", "labelfontcolor", "labelfontname", "labelfontsize", "labeltooltip", "lp", "pos", "style",
-			"taillabel", "tailport", "tailtooltip", "tail_lp", "tooltip", "xlabel", "xlp"
+			"head_lp", "id", "label", "labelfontcolor", "labelfontname", "labelfontsize", "labeltooltip", "lp", "penwidth", "pos", 
+			"style", "taillabel", "tailport", "tailtooltip", "tail_lp", "tooltip", "xlabel", "xlp"
 		], "arrowtail", '''
 			graph {
 				1--2[ arrowtail= ]
@@ -2317,7 +2317,7 @@ class DotContentAssistTests extends AbstractContentAssistTest {
 				node[«c»]
 			}
 		'''.testContentAssistant(#["]", "color", "colorscheme", "distortion", "fillcolor", "fixedsize", "fontcolor", "fontname", "fontsize",
-								"height", "id", "label", "pos", "shape", "sides", "skew", "style", "tooltip", "width",
+								"height", "id", "label", "penwidth", "pos", "shape", "sides", "skew", "style", "tooltip", "width",
 								"xlabel", "xlp"], "distortion",
 		'''
 			graph {
@@ -2331,7 +2331,7 @@ class DotContentAssistTests extends AbstractContentAssistTest {
 				1[ «c» ]
 			}
 		'''.testContentAssistant(#["]", "color", "colorscheme", "distortion", "fillcolor", "fixedsize", "fontcolor", "fontname", "fontsize",
-								"height", "id", "label", "pos", "shape", "sides", "skew", "style", "tooltip", "width",
+								"height", "id", "label", "penwidth", "pos", "shape", "sides", "skew", "style", "tooltip", "width",
 								"xlabel", "xlp"], "fixedsize",
 		'''
 			graph {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotImportTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotImportTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 itemis AG and others.
+ * Copyright (c) 2009, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -936,6 +936,33 @@ class DotImportTests {
 		DotTestGraphs.EDGE_POS_LOCAL.assertImportedTo(expected)
 	}
 
+	@Test def edge_penwidth() {
+		// test global attribute
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		val nodes = createNodes
+		val e1 = new Edge.Builder(nodes.get(0), nodes.get(1)).attr([p1,p2|p1.penwidth=p2], "1.5").buildEdge
+		val e2 = new Edge.Builder(nodes.get(2), nodes.get(3)).attr([p1,p2|p1.penwidth=p2], "1.5").buildEdge
+		var expected = graph.nodes(nodes).edges(e1, e2).build
+		
+		DotTestGraphs.EDGE_PENWIDTH_GLOBAL.assertImportedTo(expected)
+		
+		// test local attribute
+		graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		e1.penwidth = "2.5"
+		e2.penwidth = "3.0"
+		expected = graph.nodes(nodes).edges(e1, e2).build
+		
+		DotTestGraphs.EDGE_PENWIDTH_LOCAL.assertImportedTo(expected)
+		
+		// test override attribute
+		graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		e1.penwidth = "3.5"
+		e2.penwidth = "4.0"
+		expected = graph.nodes(nodes).edges(e1, e2).build
+		
+		DotTestGraphs.EDGE_PENWIDTH_OVERRIDE.assertImportedTo(expected)
+	}
+
 	@Test def edge_style() {
 		// test global attribute
 		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
@@ -1450,6 +1477,32 @@ class DotImportTests {
 		DotTestGraphs.NODE_LABEL_OVERRIDE4.assertImportedTo(expected)
 	}
 
+	@Test def node_penwidth() {
+		// test global attribute
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		val n1 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").attr([p1,p2|p1.penwidth=p2], "1.5").buildNode
+		val n2 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "2").attr([p1,p2|p1.penwidth=p2], "1.5").buildNode
+		var expected = graph.nodes(n1, n2).build
+		
+		DotTestGraphs.NODE_PENWIDTH_GLOBAL.assertImportedTo(expected)
+		
+		// test local attribute
+		graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		n1.penwidth = "2.5"
+		n2.penwidth = "3.0"
+		expected = graph.nodes(n1, n2).build
+		
+		DotTestGraphs.NODE_PENWIDTH_LOCAL.assertImportedTo(expected)
+		
+		// test override attribute
+		graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		n1.penwidth = "3.5"
+		n2.penwidth = "4.0"
+		expected = graph.nodes(n1, n2).build
+		
+		DotTestGraphs.NODE_PENWIDTH_OVERRIDE.assertImportedTo(expected)
+	}
+
 	@Test def node_pos() {
 		// no global/override attribute tests, since they do not make sense
 		// test local attribute
@@ -1652,6 +1705,19 @@ class DotImportTests {
 		val expected = graph.nodes(n1, n2).build
 		
 		DotTestGraphs.NODE_XLP_LOCAL.assertImportedTo(expected)
+	}
+
+	@Test def cluster_penwidth() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.penwidth=p2], "2")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_PENWIDTH.assertImportedTo(expected)
 	}
 
 	@Test def clusters() {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotParserTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotParserTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG and others.
+ * Copyright (c) 2016, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -101,7 +101,8 @@ class DotParserTests {
 	@Test def html_like_labels3() { "html_like_labels3.dot".dslFileHasNoError }
 	@Test def html_like_labels4() { "html_like_labels4.dot".dslFileHasNoError }
 	@Test def labeled_graph() { "labeled_graph.dot".dslFileHasNoError }
-	@Test def nodeshapes_polygon_based() { "nodeshapes_polygon_based.dot".dslFileHasNoError}
+	@Test def nodeshapes_polygon_based() { "nodeshapes_polygon_based.dot".dslFileHasNoError }
+	@Test def penwidth() { "penwidth.dot".dslFileHasNoError }
 	@Test def philo() { "philo.dot".dslFileHasNoError }
 	@Test def record_shape_node1() { "record_shape_node1.dot".dslFileHasNoError }
 	@Test def simple_digraph() { "simple_digraph.dot".dslFileHasNoError }

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotTestGraphs.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotTestGraphs.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG and others.
+ * Copyright (c) 2016, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -394,6 +394,15 @@ class DotTestGraphs {
 			graph[layout=twopi]
 			1;2;3;4;
 			1->2; 2->3; 2->4;
+		}
+	''' 
+	
+	public static val CLUSTER_PENWIDTH = '''
+		graph {
+			subgraph clusterName {
+				graph [penwidth=2];
+				1
+			}
 		}
 	''' 
 
@@ -915,6 +924,29 @@ class DotTestGraphs {
 		}
 	'''
 
+	public static val EDGE_PENWIDTH_GLOBAL = '''
+		graph {
+			edge[penwidth=1.5]
+			1--2
+			3--4
+		}
+	'''
+
+	public static val EDGE_PENWIDTH_LOCAL = '''
+		graph {
+			1--2[penwidth=2.5]
+			3--4[penwidth=3.0]
+		}
+	'''
+
+	public static val EDGE_PENWIDTH_OVERRIDE = '''
+		graph {
+			edge[penwidth=4.0]
+			1--2[penwidth=3.5]
+			3--4
+		}
+	'''
+
 	public static val EDGE_POS_LOCAL = '''
 		graph {
 			1--2[pos="0.0,0.0 1.0,1.0 2.0,2.0 3.0,3.0"]
@@ -1360,6 +1392,29 @@ class DotTestGraphs {
 			4
 			1->2
 			2->3
+		}
+	'''
+
+	public static val NODE_PENWIDTH_GLOBAL = '''
+		graph {
+			node[penwidth=1.5]
+			1
+			2
+		}
+	'''
+
+	public static val NODE_PENWIDTH_LOCAL = '''
+		graph {
+			1[penwidth=2.5]
+			2[penwidth=3.0]
+		}
+	'''
+
+	public static val NODE_PENWIDTH_OVERRIDE = '''
+		graph {
+			node[penwidth=4.0]
+			1[penwidth=3.5]
+			2
 		}
 	'''
 

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotValidatorTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotValidatorTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG and others.
+ * Copyright (c) 2016, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -157,9 +157,21 @@ class DotValidatorTests {
 		dotAst.assertError(ATTRIBUTE, LABELFONTSIZE__E, "The double value '0.3' is not semantically correct: Value may not be smaller than 1.0.")
 	}
 
+	@Test def invalid_edge_penwidth() {
+		val dotAst = '''graph { 1--2[penwidth=thin] 3--4[penwidth=-0.9]}'''.parse.assertNumberOfIssues(2)
+		dotAst.assertError(ATTRIBUTE, PENWIDTH__CNE, "The value 'thin' is not a syntactically correct double: For input string: \"thin\".")
+		dotAst.assertError(ATTRIBUTE, PENWIDTH__CNE, "The double value '-0.9' is not semantically correct: Value may not be smaller than 0.0.")
+	}
+
 	@Test def none_is_the_last_arrowshape() {
 		'''digraph { 1->2[arrowhead=boxnone] }'''.parse.assertNumberOfIssues(1).
 		assertArrowTypeWarning("The arrowType value 'boxnone' is not semantically correct: The shape 'none' may not be the last shape.")
+	}
+
+	@Test def invalid_graph_penwidth() {
+		val dotAst = '''graph { subgraph clusterName { graph[penwidth=thin] 1 } subgraph clusterOtherName {graph[penwidth=-.5] 2}}'''.parse.assertNumberOfIssues(2)
+		dotAst.assertError(ATTRIBUTE, PENWIDTH__CNE, "The value 'thin' is not a syntactically correct double: For input string: \"thin\".")
+		dotAst.assertError(ATTRIBUTE, PENWIDTH__CNE, "The double value '-.5' is not semantically correct: Value may not be smaller than 0.0.")
 	}
 
 	@Test def invalid_graph_background_color() {
@@ -224,6 +236,12 @@ class DotValidatorTests {
 		val dotAst = '''graph { 1[fontsize=large] 2[fontsize=0.3]}'''.parse.assertNumberOfIssues(2)
 		dotAst.assertError(ATTRIBUTE, FONTSIZE__GCNE, "The value 'large' is not a syntactically correct double: For input string: \"large\".")
 		dotAst.assertError(ATTRIBUTE, FONTSIZE__GCNE, "The double value '0.3' is not semantically correct: Value may not be smaller than 1.0.")
+	}
+
+	@Test def invalid_node_penwidth() {
+		val dotAst = '''graph { 1[penwidth=bold] 2[penwidth=-0.3]}'''.parse.assertNumberOfIssues(2)
+		dotAst.assertError(ATTRIBUTE, PENWIDTH__CNE, "The value 'bold' is not a syntactically correct double: For input string: \"bold\".")
+		dotAst.assertError(ATTRIBUTE, PENWIDTH__CNE, "The double value '-0.3' is not semantically correct: Value may not be smaller than 0.0.")
 	}
 
 	@Test def invalid_node_shape() {

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotAttributes.xtend
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotAttributes.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG and others.
+ * Copyright (c) 2016, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -463,6 +463,7 @@ class DotAttributes {
 			case NODESEP__G: validateAttributeRawValue(DOUBLE_PARSER, NODESEP_VALIDATOR, attributeContext, attributeName, attributeValue)
 			case OUTPUTORDER__G: validateAttributeRawValue(OUTPUTMODE_PARSER, null,	attributeContext, attributeName, attributeValue) 
 			case PAGEDIR__G: validateAttributeRawValue(PAGEDIR_PARSER, null, attributeContext, attributeName, attributeValue)
+			case PENWIDTH__CNE: validateAttributeRawValue(DOUBLE_PARSER, PENWIDTH_VALIDATOR, attributeContext, attributeName, attributeValue)
 			case POS__NE:
 				if (attributeContext == Context.NODE)
 					validateAttributeRawValue(POINT_PARSER, POINT_VALIDATOR, attributeContext, attributeName, attributeValue)
@@ -1053,11 +1054,16 @@ class DotAttributes {
 	 * A validator for nodesep {@link Double} attribute values.
 	 */
 	static val NODESEP_VALIDATOR = new DoubleValidator(0)
-	
+
 	/**
 	 * The validator for fontsize {@link Double} attribute values.
 	 */
 	static val FONTSIZE_VALIDATOR = new DoubleValidator(1.0)
+
+	/**
+	 * The validator for fontsize {@link Double} attribute values.
+	 */
+	static val PENWIDTH_VALIDATOR = new DoubleValidator(0.0)
 
 	static val Injector arrowTypeInjector = new DotArrowTypeStandaloneSetup().
 		createInjectorAndDoEMFRegistration
@@ -1524,6 +1530,9 @@ class DotAttributes {
 
 	@DotAttribute(rawType="STRING", parsedType=Pagedir)
 	public static val PAGEDIR__G = "pagedir"
+
+	@DotAttribute(rawType="NUMERAL", parsedType=Double)
+	public static val PENWIDTH__CNE = "penwidth"
 
 	/**
 	 * pos is a special case, where different parsed values for Node and Edge 

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotImport.xtend
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotImport.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 itemis AG and others.
+ * Copyright (c) 2016, 2019 itemis AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -189,6 +189,7 @@ class DotImport {
 		setter.apply(HEIGHT__N, [n, value|n.setHeightRaw(value)])
 		setter.apply(ID__GCNE, [n, value|n.setIdRaw(value)])
 		setter.apply(LABEL__GCNE, [n, value|n.setLabelRaw(value)])
+		setter.apply(PENWIDTH__CNE, [g, value|g.setPenwidthRaw(value)])
 		setter.apply(POS__NE, [n, value|n.setPosRaw(value)])
 		setter.apply(SHAPE__N, [n, value|n.setShapeRaw(value)])
 		setter.apply(SIDES__N, [n, value|n.setSidesRaw(value)])
@@ -316,6 +317,7 @@ class DotImport {
 		setter.apply(FONTSIZE__GCNE, [g, value|g.setFontsizeRaw(value)])
 		setter.apply(LABEL__GCNE, [g, value|g.setLabelRaw(value)])
 		setter.apply(RANK__S, [g, value|g.setRankRaw(value)])
+		setter.apply(PENWIDTH__CNE, [g, value|g.setPenwidthRaw(value)])
 		setter.apply(TOOLTIP__CNE, [g, value|g.setTooltipRaw(value)])
 	}
 
@@ -360,6 +362,7 @@ class DotImport {
 		setter.apply(LABELFONTSIZE__E, [e, value|e.setLabelfontsizeRaw(value)])
 		setter.apply(LABELTOOLTIP__E, [e, value|e.setLabeltooltipRaw(value)])
 		setter.apply(LP__GCE, [e, value|e.setLpRaw(value)])
+		setter.apply(PENWIDTH__CNE, [g, value|g.setPenwidthRaw(value)])
 		setter.apply(POS__NE, [e, value|e.setPosRaw(value)])
 		setter.apply(STYLE__GCNE, [e, value|e.setStyleRaw(value)])
 		setter.apply(TAILLABEL__E, [e, value|e.setTaillabelRaw(value)])


### PR DESCRIPTION
- Implement penwidth attribute support in DotAttributes and DotImport
- Implement corresponding DotAttributeTests, DotContentAssistTests,
DotImportTests, DotParserTests, DotTestGraphs, DotValidatorTests

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461506