### PR TITLE
[542663] Use of the DotFontNameParser in DotAttributes

### DIFF
--- a/org.eclipse.gef.dot.tests/resources/fontname_fontsize.dot
+++ b/org.eclipse.gef.dot.tests/resources/fontname_fontsize.dot
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG and others.
+ * Copyright (c) 2018, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *       Zoey Gerrit Prigge (itemis AG) - Initial text (bug #461506)
+ *                                      - Add pango font name (bug #542663)
  *
  *******************************************************************************/
  
@@ -17,6 +18,8 @@
 
 digraph{
 	9 -> 10 -> 11 -> 12 [labelfontname="Times", labelfontsize=10];
+
+PangoTestNode [fontname="One Font, Second Font Bold"];
 
 9[ fontname="Courier" fontsize=11 shape=box width=0 height=0 margin="0,0"
 	label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotAttributesTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotAttributesTests.xtend
@@ -27,6 +27,8 @@ import org.eclipse.gef.dot.internal.language.dir.DirType
 import org.eclipse.gef.dot.internal.language.dot.GraphType
 import org.eclipse.gef.dot.internal.language.escstring.EscstringFactory
 import org.eclipse.gef.dot.internal.language.escstring.Justification
+import org.eclipse.gef.dot.internal.language.fontname.FontnameFactory
+import org.eclipse.gef.dot.internal.language.fontname.PostScriptFontAlias
 import org.eclipse.gef.dot.internal.language.layout.Layout
 import org.eclipse.gef.dot.internal.language.outputmode.OutputMode
 import org.eclipse.gef.dot.internal.language.pagedir.Pagedir
@@ -69,6 +71,7 @@ class DotAttributesTests {
 	val extension ColorFactory = ColorFactory.eINSTANCE
 	val extension ColorlistFactory = ColorlistFactory.eINSTANCE
 	val extension EscstringFactory = EscstringFactory.eINSTANCE
+	val extension FontnameFactory = FontnameFactory.eINSTANCE
 	val extension PointFactory = PointFactory.eINSTANCE
 	val extension PortposFactory = PortposFactory.eINSTANCE
 	val extension RectFactory = RectFactory.eINSTANCE
@@ -512,11 +515,31 @@ class DotAttributesTests {
 		// test getters if no explicit value is set
 		fontnameRaw.assertNull
 		fontname.assertNull
+		fontnameParsed.assertNull
 		
-		// set valid string values
-		val validEdgeFontname = "Times New Roman"
-		fontname = validEdgeFontname
-		validEdgeFontname.assertEquals(fontname)
+		val validPostScriptParsed = createPostScriptFontName => [ alias = PostScriptFontAlias.TIMES_ROMAN]
+		val validPostScriptString = "Times-Roman"
+		
+		//String setter
+		fontname = validPostScriptString
+		validPostScriptString.assertEquals(fontname)
+		EcoreUtil.equals(validPostScriptParsed, fontnameParsed).assertTrue
+		//Parsed setter
+		fontnameParsed = validPostScriptParsed
+		validPostScriptString.assertEquals(fontname)
+		EcoreUtil.equals(validPostScriptParsed, fontnameParsed).assertTrue
+		
+		val validPangoParsed = createPangoFontName => [ families += "Times"]
+		val validPangoString = "Times,"
+		
+		//String setter
+		fontname = validPangoString
+		validPangoString.assertEquals(fontname)
+		EcoreUtil.equals(validPangoParsed, fontnameParsed).assertTrue
+		//Parsed setter
+		fontnameParsed = validPangoParsed
+		validPangoString.assertEquals(fontname)
+		EcoreUtil.equals(validPangoParsed, fontnameParsed).assertTrue
 	}
 
 	@Test def edge_fontsize() {
@@ -761,11 +784,31 @@ class DotAttributesTests {
 		// test getters if no explicit value is set
 		labelfontnameRaw.assertNull
 		labelfontname.assertNull
+		labelfontnameParsed.assertNull
 		
-		// set valid string values
-		val validEdgeLabelfontname = "Times New Roman"
-		labelfontname = validEdgeLabelfontname
-		validEdgeLabelfontname.assertEquals(labelfontname)
+		val validPostScriptParsed = createPostScriptFontName => [ alias = PostScriptFontAlias.TIMES_ROMAN]
+		val validPostScriptString = "Times-Roman"
+		
+		//String setter
+		labelfontname = validPostScriptString
+		validPostScriptString.assertEquals(labelfontname)
+		EcoreUtil.equals(validPostScriptParsed, labelfontnameParsed).assertTrue
+		//Parsed setter
+		labelfontnameParsed = validPostScriptParsed
+		validPostScriptString.assertEquals(labelfontname)
+		EcoreUtil.equals(validPostScriptParsed, labelfontnameParsed).assertTrue
+		
+		val validPangoParsed = createPangoFontName => [ families += "Times"]
+		val validPangoString = "Times,"
+		
+		//String setter
+		labelfontname = validPangoString
+		validPangoString.assertEquals(labelfontname)
+		EcoreUtil.equals(validPangoParsed, labelfontnameParsed).assertTrue
+		//Parsed setter
+		labelfontnameParsed = validPangoParsed
+		validPangoString.assertEquals(labelfontname)
+		EcoreUtil.equals(validPangoParsed, labelfontnameParsed).assertTrue
 	}
 
 	@Test def edge_labelfontsize() {
@@ -1601,11 +1644,31 @@ class DotAttributesTests {
 		// test getters if no explicit value is set
 		fontnameRaw.assertNull
 		fontname.assertNull
+		fontnameParsed.assertNull
 		
-		// set valid string values
-		val validGraphFontname = "Times New Roman"
-		fontname = validGraphFontname
-		validGraphFontname.assertEquals(fontname)
+		val validPostScriptParsed = createPostScriptFontName => [ alias = PostScriptFontAlias.TIMES_ROMAN]
+		val validPostScriptString = "Times-Roman"
+		
+		//String setter
+		fontname = validPostScriptString
+		validPostScriptString.assertEquals(fontname)
+		EcoreUtil.equals(validPostScriptParsed, fontnameParsed).assertTrue
+		//Parsed setter
+		fontnameParsed = validPostScriptParsed
+		validPostScriptString.assertEquals(fontname)
+		EcoreUtil.equals(validPostScriptParsed, fontnameParsed).assertTrue
+		
+		val validPangoParsed = createPangoFontName => [ families += "Times"]
+		val validPangoString = "Times,"
+		
+		//String setter
+		fontname = validPangoString
+		validPangoString.assertEquals(fontname)
+		EcoreUtil.equals(validPangoParsed, fontnameParsed).assertTrue
+		//Parsed setter
+		fontnameParsed = validPangoParsed
+		validPangoString.assertEquals(fontname)
+		EcoreUtil.equals(validPangoParsed, fontnameParsed).assertTrue
 	}
 
 	@Test def graph_fontsize() {
@@ -2644,11 +2707,31 @@ class DotAttributesTests {
 		// test getters if no explicit value is set
 		fontnameRaw.assertNull
 		fontname.assertNull
+		fontnameParsed.assertNull
 		
-		// set valid string values
-		val validNodeFontname = "Times New Roman"
-		fontname = validNodeFontname
-		validNodeFontname.assertEquals(fontname)
+		val validPostScriptParsed = createPostScriptFontName => [ alias = PostScriptFontAlias.TIMES_ROMAN]
+		val validPostScriptString = "Times-Roman"
+		
+		//String setter
+		fontname = validPostScriptString
+		validPostScriptString.assertEquals(fontname)
+		EcoreUtil.equals(validPostScriptParsed, fontnameParsed).assertTrue
+		//Parsed setter
+		fontnameParsed = validPostScriptParsed
+		validPostScriptString.assertEquals(fontname)
+		EcoreUtil.equals(validPostScriptParsed, fontnameParsed).assertTrue
+		
+		val validPangoParsed = createPangoFontName => [ families += "Times"]
+		val validPangoString = "Times,"
+		
+		//String setter
+		fontname = validPangoString
+		validPangoString.assertEquals(fontname)
+		EcoreUtil.equals(validPangoParsed, fontnameParsed).assertTrue
+		//Parsed setter
+		fontnameParsed = validPangoParsed
+		validPangoString.assertEquals(fontname)
+		EcoreUtil.equals(validPangoParsed, fontnameParsed).assertTrue
 	}
 
 	@Test def node_fontsize() {

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotAttributes.xtend
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotAttributes.xtend
@@ -30,6 +30,7 @@ import org.eclipse.gef.dot.internal.language.DotArrowTypeStandaloneSetup
 import org.eclipse.gef.dot.internal.language.DotColorListStandaloneSetup
 import org.eclipse.gef.dot.internal.language.DotColorStandaloneSetup
 import org.eclipse.gef.dot.internal.language.DotEscStringStandaloneSetup
+import org.eclipse.gef.dot.internal.language.DotFontNameStandaloneSetup
 import org.eclipse.gef.dot.internal.language.DotHtmlLabelStandaloneSetup
 import org.eclipse.gef.dot.internal.language.DotPointStandaloneSetup
 import org.eclipse.gef.dot.internal.language.DotPortPosStandaloneSetup
@@ -52,6 +53,7 @@ import org.eclipse.gef.dot.internal.language.dot.GraphType
 import org.eclipse.gef.dot.internal.language.dot.NodeStmt
 import org.eclipse.gef.dot.internal.language.dot.Subgraph
 import org.eclipse.gef.dot.internal.language.escstring.EscString
+import org.eclipse.gef.dot.internal.language.fontname.FontName
 import org.eclipse.gef.dot.internal.language.htmllabel.HtmlLabel
 import org.eclipse.gef.dot.internal.language.layout.Layout
 import org.eclipse.gef.dot.internal.language.outputmode.OutputMode
@@ -442,6 +444,7 @@ class DotAttributes {
 				}else
 					Collections.emptyList
 			case FONTCOLOR__GCNE: validateAttributeRawValue(COLOR_PARSER, COLOR_VALIDATOR, attributeContext, attributeName, attributeValue)
+			case FONTNAME__GCNE: validateAttributeRawValue(FONTNAME_PARSER, null, attributeContext, attributeName, attributeValue)
 			case FONTSIZE__GCNE: validateAttributeRawValue(DOUBLE_PARSER, FONTSIZE_VALIDATOR, attributeContext, attributeName, attributeValue)
 			case FORCELABELS__G: validateAttributeRawValue(BOOL_PARSER, null, attributeContext, FORCELABELS__G, attributeValue)
 			case HEAD_LP__E: validateAttributeRawValue(POINT_PARSER, POINT_VALIDATOR, attributeContext, attributeName, attributeValue)
@@ -456,8 +459,9 @@ class DotAttributes {
 				else
 					Collections.emptyList
 			case LABELFONTCOLOR__E: validateAttributeRawValue(COLOR_PARSER, COLOR_VALIDATOR, attributeContext, attributeName, attributeValue)
-			case LABELTOOLTIP__E: validateAttributeRawValue(ESCSTRING_PARSER, ESCSTRING_VALIDATOR, attributeContext, attributeName, attributeValue)
+			case LABELFONTNAME__E: validateAttributeRawValue(FONTNAME_PARSER, null, attributeContext, attributeName, attributeValue)
 			case LABELFONTSIZE__E: validateAttributeRawValue(DOUBLE_PARSER, FONTSIZE_VALIDATOR, attributeContext, attributeName, attributeValue)
+			case LABELTOOLTIP__E: validateAttributeRawValue(ESCSTRING_PARSER, ESCSTRING_VALIDATOR, attributeContext, attributeName, attributeValue)
 			case LAYOUT__G: validateAttributeRawValue(LAYOUT_PARSER, null, attributeContext, attributeName, attributeValue)
 			case LP__GCE: validateAttributeRawValue(POINT_PARSER, POINT_VALIDATOR, attributeContext, attributeName, attributeValue)
 			case NODESEP__G: validateAttributeRawValue(DOUBLE_PARSER, NODESEP_VALIDATOR, attributeContext, attributeName, attributeValue)
@@ -1137,6 +1141,18 @@ class DotAttributes {
 	static val ESCSTRING_VALIDATOR = new EObjectValidator<EscString>(escStringInjector,
 		DotEscStringJavaValidator)
 
+	static val Injector fontNameInjector = new DotFontNameStandaloneSetup().createInjectorAndDoEMFRegistration
+
+	/**
+	 * The parser for fontname attribute values.
+	 */
+	static val FONTNAME_PARSER = new EObjectParser<FontName>(fontNameInjector)
+
+	/**
+	 * The serializer for fontname attribute values.
+	 */
+	static val FONTNAME_SERIALIZER = new EObjectSerializer<FontName>(fontNameInjector)
+
 	static val Injector rectInjector = new DotRectStandaloneSetup().createInjectorAndDoEMFRegistration
 
 	/**
@@ -1474,7 +1490,7 @@ class DotAttributes {
 	@DotAttribute(parsedType=Color)
 	public static val FONTCOLOR__GCNE = "fontcolor"
 	
-	@DotAttribute(parsedType=String)
+	@DotAttribute(parsedType=FontName)
 	public static val FONTNAME__GCNE = "fontname"
 	
 	@DotAttribute(rawType="NUMERAL", parsedType=Double)
@@ -1507,7 +1523,7 @@ class DotAttributes {
 	@DotAttribute(parsedType=Color)
 	public static val LABELFONTCOLOR__E = "labelfontcolor"
 	
-	@DotAttribute(parsedType=String)
+	@DotAttribute(parsedType=FontName)
 	public static val LABELFONTNAME__E = "labelfontname"
 	
 	@DotAttribute(rawType="NUMERAL", parsedType=Double)


### PR DESCRIPTION
-Implement corresponding DotAttributesTests
-add Pango example to fontname_fontsize.dot

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=542663