### PR TITLE
[541056] Adapt DotGraphView to use FontName

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG and others.
+ * Copyright (c) 2018, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -275,13 +275,16 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_label008() {
+		mockAvailableFonts("Bitstream Vera Sans")
 		'''
 			digraph {
 				edge[fontname=Helvetica]
 				1->2[label=l]
 			}
 		'''.assertEdgeLabelCssStyle('''
-			-fx-font-family: "Helvetica";
+			-fx-font-family: "Bitstream Vera Sans";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
@@ -297,13 +300,16 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_label010() {
+		mockAvailableFonts("Bitstream Vera Sans")
 		'''
 			digraph {
 				1->2[label=l, fontcolor=red, fontname=Helvetica, fontsize=16]
 			}
 		'''.assertEdgeLabelCssStyle('''
 			-fx-fill: #ff0000;
-			-fx-font-family: "Helvetica";
+			-fx-font-family: "Bitstream Vera Sans";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 			-fx-font-size: 16.0;
 		''')
 	}
@@ -362,13 +368,16 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_externalLabel007() {
+		mockAvailableFonts("Arial")
 		'''
 			digraph {
 				edge[fontname=Helvetica]
 				1->2[xlabel=x]
 			}
 		'''.assertEdgeExternalLabelCssStyle('''
-			-fx-font-family: "Helvetica";
+			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
@@ -384,6 +393,7 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_externalLabel009() {
+		mockAvailableFonts("Arial")
 		'''
 			digraph {
 				edge[fontcolor=red, fontname=Helvetica, fontsize=16]
@@ -391,7 +401,9 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeExternalLabelCssStyle('''
 			-fx-fill: #ff0000;
-			-fx-font-family: "Helvetica";
+			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 			-fx-font-size: 16.0;
 		''')
 	}
@@ -472,24 +484,30 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_sourceLabel010() {
+		mockAvailableFonts("Times New Roman", "Helvetica")
 		'''
 			digraph {
-				edge[fontname=Arial]
+				edge[fontname=Helvetica]
 				1->2[taillabel=t]
 			}
 		'''.assertEdgeSourceLabelCssStyle('''
-			-fx-font-family: "Arial";
+			-fx-font-family: "Helvetica";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
 	@Test def edge_sourceLabel011() {
+		mockAvailableFonts("Times New Roman", "Helvetica")
 		'''
 			digraph {
-				edge[labelfontname="Times New Roman", fontname=Arial]
+				edge[labelfontname="Times-Roman", fontname=Helvetica]
 				1->2[taillabel=t]
 			}
 		'''.assertEdgeSourceLabelCssStyle('''
 			-fx-font-family: "Times New Roman";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
@@ -516,14 +534,17 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_sourceLabel014() {
+		mockAvailableFonts("Courier New")
 		'''
 			digraph {
-				edge[labelfontsize=14, fontsize=12, fontcolor=green, fontname="Courier New"]
+				edge[labelfontsize=14, fontsize=12, fontcolor=green, fontname="Courier"]
 				1->2[taillabel=t]
 			}
 		'''.assertEdgeSourceLabelCssStyle('''
 			-fx-fill: #00ff00;
 			-fx-font-family: "Courier New";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 			-fx-font-size: 14.0;
 		''')
 	}
@@ -613,6 +634,7 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_targetLabel010() {
+		mockAvailableFonts("Arial")
 		'''
 			digraph {
 				edge[fontname=Arial]
@@ -620,17 +642,22 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeTargetLabelCssStyle('''
 			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
 	@Test def edge_targetLabel011() {
+		mockAvailableFonts("Liberation Serif", "Liberation Sans")
 		'''
 			digraph {
-				edge[labelfontname="Times New Roman", fontname=Arial]
+				edge[labelfontname="Times-BoldItalic", fontname=Helvetica]
 				1->2[headlabel=h]
 			}
 		'''.assertEdgeTargetLabelCssStyle('''
-			-fx-font-family: "Times New Roman";
+			-fx-font-family: "Liberation Serif";
+			-fx-font-weight: 700;
+			-fx-font-style: italic;
 		''')
 	}
 
@@ -657,6 +684,7 @@ class Dot2ZestEdgeAttributesConversionTests {
 	}
 
 	@Test def edge_targetLabel014() {
+		mockAvailableFonts("Courier New")
 		'''
 			digraph {
 				edge[labelfontsize=14, fontsize=12, fontcolor=green, fontname="Courier New"]
@@ -665,7 +693,23 @@ class Dot2ZestEdgeAttributesConversionTests {
 		'''.assertEdgeTargetLabelCssStyle('''
 			-fx-fill: #00ff00;
 			-fx-font-family: "Courier New";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 			-fx-font-size: 14.0;
+		''')
+	}
+	
+	@Test def edge_targetLabel015() {
+		mockAvailableFonts("Serif")
+		'''
+			digraph {
+				edge[fontname="Bookman-Light"]
+				1->2[headlabel=h]
+			}
+		'''.assertEdgeTargetLabelCssStyle('''
+			-fx-font-family: "serif";
+			-fx-font-weight: 300;
+			-fx-font-style: normal;
 		''')
 	}
 
@@ -769,5 +813,8 @@ class Dot2ZestEdgeAttributesConversionTests {
 	private def split(String text) {
 		text.replaceAll(";", ";" + System.lineSeparator)
 	}
-
+	
+	private def mockAvailableFonts(String... availableFonts) {
+		fontUtil.systemFontAccess = new DotFontAccessMock(availableFonts)
+	}
 }

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG and others.
+ * Copyright (c) 2018, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -485,6 +485,7 @@ class Dot2ZestGraphCopierTests {
 	}
 
 	@Test def edge_fontname() {
+		mockAvailableFonts("Comic Sans")
 		'''
 			digraph {
 				1->2[fontname="Comic Sans", label="foo"]
@@ -506,7 +507,7 @@ class Dot2ZestGraphCopierTests {
 					edge-curve-css-style : -fx-stroke-line-cap: butt;
 					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
 					element-label : foo
-					element-label-css-style : -fx-font-family: "Comic Sans";
+					element-label-css-style : -fx-font-family: "Comic Sans";-fx-font-weight: 400;-fx-font-style: normal;
 				}
 			}
 		''')
@@ -895,12 +896,14 @@ class Dot2ZestGraphCopierTests {
 	}
 
 	@Test def edge_labelfontname() {
+		mockAvailableFonts("Arial", "Comic Sans", "Times New Roman")
 		// If unset, the fontcolor value is used.
 		'''
 			digraph {
 				1->2[fontname="Arial", labelfontname="Courier New", label="foo", headlabel="baa"]
 				1->3[labelfontname="Times New Roman", headlabel="baa"]
 				2->3[fontname="Comic Sans", label="foo", headlabel="baa"]
+				3->4[fontname="Times-Bold", label="faa"]
 			}
 		'''.assertZestConversion('''
 			Graph {
@@ -919,30 +922,42 @@ class Dot2ZestGraphCopierTests {
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
+				Node4 {
+					element-label : 4
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
 				Edge1 from Node1 to Node2 {
 					edge-curve : GeometryNode
 					edge-curve-css-style : -fx-stroke-line-cap: butt;
 					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
 					edge-target-label : baa
-					edge-target-label-css-style : -fx-font-family: "Courier New";
+					edge-target-label-css-style : -fx-font-family: "System";-fx-font-weight: 400;-fx-font-style: normal;
 					element-label : foo
-					element-label-css-style : -fx-font-family: "Arial";
+					element-label-css-style : -fx-font-family: "Arial";-fx-font-weight: 400;-fx-font-style: normal;
 				}
 				Edge2 from Node1 to Node3 {
 					edge-curve : GeometryNode
 					edge-curve-css-style : -fx-stroke-line-cap: butt;
 					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
 					edge-target-label : baa
-					edge-target-label-css-style : -fx-font-family: "Times New Roman";
+					edge-target-label-css-style : -fx-font-family: "System";-fx-font-weight: 400;-fx-font-style: normal;
 				}
 				Edge3 from Node2 to Node3 {
 					edge-curve : GeometryNode
 					edge-curve-css-style : -fx-stroke-line-cap: butt;
 					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
 					edge-target-label : baa
-					edge-target-label-css-style : -fx-font-family: "Comic Sans";
+					edge-target-label-css-style : -fx-font-family: "Comic Sans";-fx-font-weight: 400;-fx-font-style: normal;
 					element-label : foo
-					element-label-css-style : -fx-font-family: "Comic Sans";
+					element-label-css-style : -fx-font-family: "Comic Sans";-fx-font-weight: 400;-fx-font-style: normal;
+				}
+				Edge4 from Node3 to Node4 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+					element-label : faa
+					element-label-css-style : -fx-font-family: "Times New Roman";-fx-font-weight: 700;-fx-font-style: normal;
 				}
 			}
 		''')
@@ -1501,10 +1516,11 @@ class Dot2ZestGraphCopierTests {
 	}
 
 	@Test def graph_fontname() {
+		//replaceFontAccess("Times New Roman")
 		// This test shows current behaviour, it needs adaptation once the attribute is supported.
 		'''
 			digraph {
-				graph [label="foo", fontname="Times New Roman"];
+				graph [label="foo", fontname="Times-Roman"];
 				1
 			}
 		'''.assertZestConversion('''
@@ -2504,7 +2520,8 @@ class Dot2ZestGraphCopierTests {
 		''')
 	}
 
-	@Test def node_fontname() {
+	@Test def node_fontname001() {
+		mockAvailableFonts("Arial", "Helvetica")
 		'''
 			graph {
 				1[fontname="Helvetica"]
@@ -2513,7 +2530,25 @@ class Dot2ZestGraphCopierTests {
 			Graph {
 				Node1 {
 					element-label : 1
-					element-label-css-style : -fx-font-family: "Helvetica";
+					element-label-css-style : -fx-font-family: "Helvetica";-fx-font-weight: 400;-fx-font-style: normal;
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+	
+	@Test def node_fontname002() {
+		mockAvailableFonts("Arial")
+		'''
+			graph {
+				1[fontname="Helvetica"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					element-label-css-style : -fx-font-family: "Arial";-fx-font-weight: 400;-fx-font-style: normal;
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -4175,6 +4210,10 @@ class Dot2ZestGraphCopierTests {
 		val regex = '''(@[^\\«nl»]*)'''
 		
 		text.replaceAll(regex, "")
+	}
+	
+	private def mockAvailableFonts(String... availableFonts) {
+		dot2ZestGraphCopier.attributeCopier.fontUtil.systemFontAccess = new DotFontAccessMock(availableFonts)
 	}
 
 	private static class NodeShapePrettyPrinter extends DotGraphPrettyPrinter {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG and others.
+ * Copyright (c) 2018, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -123,22 +123,28 @@ class Dot2ZestNodeAttributesConversionTests {
 	}
 
 	@Test def node_fontname001() {
+		mockAvailableFonts("Arial")
 		'''
 			graph {
 				1[fontname=Arial]
 			}
 		'''.assertNodeLabelCssStyle('''
 			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
 	@Test def node_fontname002() {
+		mockAvailableFonts("Arial")
 		'''
 			graph {
 				1[xlabel="x", fontname=Arial]
 			}
 		'''.assertNodeXLabelCssStyle('''
 			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 		''')
 	}
 
@@ -163,6 +169,7 @@ class Dot2ZestNodeAttributesConversionTests {
 	}
 
 	@Test def node_fontstyles_combined001() {
+		mockAvailableFonts("Arial")
 		'''
 			graph {
 				1[fontcolor=red, fontname="Arial", fontsize="3.5"]
@@ -170,11 +177,14 @@ class Dot2ZestNodeAttributesConversionTests {
 		'''.assertNodeLabelCssStyle('''
 			-fx-fill: #ff0000;
 			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 			-fx-font-size: 3.5;
 		''')
 	}
 
 	@Test def node_fontstyles_combined002() {
+		mockAvailableFonts("Arial")
 		'''
 			graph {
 				1[xlabel="x", fontcolor=red, fontname="Arial", fontsize="3.5"]
@@ -182,6 +192,8 @@ class Dot2ZestNodeAttributesConversionTests {
 		'''.assertNodeXLabelCssStyle('''
 			-fx-fill: #ff0000;
 			-fx-font-family: "Arial";
+			-fx-font-weight: 400;
+			-fx-font-style: normal;
 			-fx-font-size: 3.5;
 		''')
 	}
@@ -800,5 +812,9 @@ class Dot2ZestNodeAttributesConversionTests {
 
 	private def split(String text) {
 		text.replaceAll(";", ";" + System.lineSeparator)
+	}
+	
+	private def mockAvailableFonts(String... availableFonts) {
+		fontUtil.systemFontAccess = new DotFontAccessMock(availableFonts)
 	}
 }

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotFontAccessMock.java
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotFontAccessMock.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - initial API and implementation (bug #541056)
+ *     
+ *******************************************************************************/
+package org.eclipse.gef.dot.tests;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.eclipse.gef.dot.internal.ui.DotFontUtil;
+import org.eclipse.gef.dot.internal.ui.DotFontUtil.Font;
+
+public class DotFontAccessMock implements DotFontUtil.SystemFontAccess {
+	private final String[] availableFonts;
+
+	public DotFontAccessMock(String... availableFonts) {
+		this.availableFonts = availableFonts;
+	}
+
+	@Override
+	public FakeFont font(String family) {
+		if (Arrays.stream(availableFonts)
+				.filter(availableFont -> availableFont.equalsIgnoreCase(family))
+				.collect(Collectors.counting()) > 0) {
+			return new FakeFont(family);
+		}
+		return getDefault();
+	}
+
+	@Override
+	public FakeFont getDefault() {
+		return new FakeFont("System");
+	}
+
+	class FakeFont implements DotFontUtil.Font {
+		private final String family;
+
+		FakeFont(String family) {
+			this.family = family;
+		}
+
+		@Override
+		public String getFamily() {
+			return family;
+		}
+
+		@Override
+		public boolean equals(Font font) {
+			return font instanceof FakeFont
+					&& family.equals(((FakeFont) font).family);
+		}
+	}
+}

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 itemis AG and others.
+ * Copyright (c) 2015, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,6 +38,7 @@ import org.eclipse.gef.dot.internal.language.dir.DirType;
 import org.eclipse.gef.dot.internal.language.dot.GraphType;
 import org.eclipse.gef.dot.internal.language.escstring.EscString;
 import org.eclipse.gef.dot.internal.language.escstring.JustifiedText;
+import org.eclipse.gef.dot.internal.language.fontname.FontName;
 import org.eclipse.gef.dot.internal.language.layout.Layout;
 import org.eclipse.gef.dot.internal.language.rankdir.Rankdir;
 import org.eclipse.gef.dot.internal.language.shape.PolygonBasedNodeShape;
@@ -111,6 +112,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 	}
 
 	private DotColorUtil colorUtil = new DotColorUtil();
+	public final DotFontUtil fontUtil = new DotFontUtil();
 
 	@Override
 	public void copy(IAttributeStore source, IAttributeStore target) {
@@ -475,7 +477,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 	private String computeZestEdgeLabelCssStyle(Edge dot) {
 		Color dotColor = DotAttributes.getFontcolorParsed(dot);
 		String dotColorScheme = DotAttributes.getColorscheme(dot);
-		String dotFont = DotAttributes.getFontname(dot);
+		FontName dotFont = DotAttributes.getFontnameParsed(dot);
 		Double dotSize = DotAttributes.getFontsizeParsed(dot);
 		return computeZestLabelCssStyle(dotColor, dotColorScheme, dotFont,
 				dotSize);
@@ -487,9 +489,9 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 			dotColor = DotAttributes.getFontcolorParsed(dot);
 		}
 		String dotColorScheme = DotAttributes.getColorscheme(dot);
-		String dotFont = DotAttributes.getLabelfontname(dot);
+		FontName dotFont = DotAttributes.getLabelfontnameParsed(dot);
 		if (dotFont == null) {
-			dotFont = DotAttributes.getFontname(dot);
+			dotFont = DotAttributes.getFontnameParsed(dot);
 		}
 		Double dotSize = DotAttributes.getLabelfontsizeParsed(dot);
 		if (dotSize == null) {
@@ -500,7 +502,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 	}
 
 	private String computeZestLabelCssStyle(Color dotColor,
-			String dotColorScheme, String dotFont, Double dotSize) {
+			String dotColorScheme, FontName dotFont, Double dotSize) {
 		StringBuilder zestStyle = new StringBuilder();
 		if (dotColor != null) {
 			String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
@@ -511,10 +513,16 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 				zestStyle.append(";"); //$NON-NLS-1$
 			}
 		}
-		if (dotFont != null && dotFont.length() > 0) {
+		if (dotFont != null) {
 			zestStyle.append("-fx-font-family: \""); //$NON-NLS-1$
-			zestStyle.append(dotFont);
+			zestStyle.append(fontUtil.cssLocalFontFamily(dotFont));
 			zestStyle.append("\";"); //$NON-NLS-1$
+			zestStyle.append("-fx-font-weight: "); //$NON-NLS-1$
+			zestStyle.append(fontUtil.cssWeight(dotFont));
+			zestStyle.append(";"); //$NON-NLS-1$
+			zestStyle.append("-fx-font-style: "); //$NON-NLS-1$
+			zestStyle.append(fontUtil.cssStyle(dotFont));
+			zestStyle.append(";"); //$NON-NLS-1$
 		}
 		if (dotSize != null) {
 			zestStyle.append("-fx-font-size: "); //$NON-NLS-1$
@@ -657,7 +665,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 					dotLabel, DotAttributes.getFontname(dot),
 					DotAttributes.getFontsize(dot),
 					DotAttributes.getFontcolor(dot),
-					DotAttributes.getColorscheme(dot));
+					DotAttributes.getColorscheme(dot), colorUtil, fontUtil);
 			ZestProperties.setShape(zest, htmlNode.getFxElement());
 			// TODO Surround the HTML label with the shape as set above
 
@@ -854,7 +862,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 	private String computeZestNodeLabelCssStyle(Node dot) {
 		Color dotColor = DotAttributes.getFontcolorParsed(dot);
 		String dotColorScheme = DotAttributes.getColorscheme(dot);
-		String dotFont = DotAttributes.getFontname(dot);
+		FontName dotFont = DotAttributes.getFontnameParsed(dot);
 		Double dotSize = DotAttributes.getFontsizeParsed(dot);
 		return computeZestLabelCssStyle(dotColor, dotColorScheme, dotFont,
 				dotSize);

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotFontUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotFontUtil.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - initial API and implementation (bug #541056)
+ *     
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.ui;
+
+import java.io.StringReader;
+import java.util.Locale;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.dot.internal.language.fontname.FontName;
+import org.eclipse.gef.dot.internal.language.fontname.Weight;
+import org.eclipse.gef.dot.internal.ui.language.internal.DotActivator;
+import org.eclipse.xtext.parser.IParser;
+
+public class DotFontUtil {
+	private SystemFontAccess access = new JavafxFontAccess();
+
+	public String cssLocalFontFamily(FontName name) {
+		return findLocalFamily(name).getFamily();
+	}
+
+	private Font findLocalFamily(FontName dotFont) {
+		Font font = access.getDefault();
+		for (String alternative : dotFont.getFontFamilies()) {
+			font = access.font(alternative);
+			if (!isDefaultFont(font)) {
+				break;
+			}
+		}
+		return font;
+	}
+
+	private boolean isDefaultFont(Font font) {
+		return font == null || font.equals(access.getDefault());
+	}
+
+	public String cssWeight(FontName dotFont) {
+		Weight weight = dotFont.getWeight();
+		return Integer.toString(intWeight(weight));
+	}
+
+	private int intWeight(Weight weight) {
+		if (weight == null) {
+			weight = Weight.NORMAL;
+		}
+		switch (weight) {
+		case THIN:
+			return 100;
+		case ULTRALIGHT:
+			return 200;
+		case LIGHT:
+			return 300;
+		case SEMILIGHT:
+			return 350;
+		case BOOK:
+			return 380;
+		case MEDIUM:
+			return 500;
+		case SEMIBOLD:
+			return 600;
+		case BOLD:
+			return 700;
+		case ULTRABOLD:
+			return 800;
+		case HEAVY:
+		case ULTRAHEAVY: // normally 1000, not supported by javafx
+			return 900;
+		case NORMAL:
+		default:
+			return 400;
+
+		}
+	}
+
+	public String cssStyle(FontName dotFont) {
+		return dotFont.getStyle() != null
+				? dotFont.getStyle().getName().toLowerCase(Locale.ENGLISH)
+				: "normal"; //$NON-NLS-1$
+	}
+
+	public FontName parseHtmlFontFace(String face) {
+		if (face == null) {
+			return null;
+		}
+		IParser parser = DotActivator.getInstance().getInjector(
+				DotActivator.ORG_ECLIPSE_GEF_DOT_INTERNAL_LANGUAGE_DOTFONTNAME)
+				.getInstance(IParser.class);
+		EObject rootNode = parser.parse(new StringReader(face))
+				.getRootASTElement();
+		if (rootNode instanceof FontName) {
+			return (FontName) rootNode;
+		}
+		return null;
+	}
+
+	public interface SystemFontAccess {
+		public Font getDefault();
+
+		public Font font(String family);
+	}
+
+	public interface Font {
+		public String getFamily();
+
+		public boolean equals(Font font);
+	}
+
+	final class JavafxFontAccess implements SystemFontAccess {
+		final class JavaFxFont implements Font {
+			private final javafx.scene.text.Font fxFont;
+
+			JavaFxFont(javafx.scene.text.Font fxFont) {
+				this.fxFont = fxFont;
+			}
+
+			@Override
+			public String getFamily() {
+				return fxFont.getFamily();
+			}
+
+			@Override
+			public boolean equals(Font font) {
+				return font instanceof JavaFxFont
+						&& fxFont.equals(((JavaFxFont) font).fxFont);
+			}
+		}
+
+		@Override
+		public Font getDefault() {
+			return new JavaFxFont(javafx.scene.text.Font.getDefault());
+		}
+
+		@Override
+		public Font font(String family) {
+			return new JavaFxFont(javafx.scene.text.Font.font(family));
+		}
+	}
+
+	public void setSystemFontAccess(SystemFontAccess access) {
+		this.access = access;
+	}
+}


### PR DESCRIPTION
-implement a DotFontUtil to translate a FontName to JavaFX CSS
-implement usage of parsed FontName in Dot2ZestAttributeConverter
-implement an HTML font parsing helper method in DotFontUtil
-use DotFontUtil for HTML <font> tags
-adapt Tests and provide DotFontAccessMock

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
https://bugs.eclipse.org/bugs/show_bug.cgi?id=541056