### PR TITLE
[545801] Improve content assist support for quoted attributes

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotContentAssistTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotContentAssistTests.xtend
@@ -9,6 +9,7 @@
  * Contributors:
  *     Tamas Miklossy     (itemis AG) - initial implementation (bug #498324)
  *     Zoey Gerrit Prigge (itemis AG) - Add support for additional dot attributes (bug #461506)
+ *                                    - Improve CA support for quoted attributes (bug #545801)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.tests
@@ -3406,7 +3407,9 @@ class DotContentAssistTests extends AbstractContentAssistTest {
 				try {
 					val configuration = injector.getInstance(XtextSourceViewerConfiguration)
 					val sourceViewer = getSourceViewer(shell, document, configuration)
-					return appendAndApplyProposal(proposal, sourceViewer, getModel(), position)
+					// use appendAndApplyProposal as a workaround (also see comment above)
+					// use null model, as document already contains model
+					return appendAndApplyProposal(proposal, sourceViewer, null, position)
 				} finally {
 					shell.dispose
 				}


### PR DESCRIPTION
- Rewrite currentModel instanceof Attribute section of
createCompletionProposal in DotProposalProvider to improve content
assist with selections and quoted attribute values using a PrefixMatcher
& IReplacementTextApplier.
- move logic from proposeAttributeValues (list signature) to
abovementioned rewritten section
- fix a bug in helper method in DotContentAssistTest

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=545801