### PR TITLE
[541056] Application of Label Css Style on Clusters / DotFontUtil Fix

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
@@ -1516,7 +1516,7 @@ class Dot2ZestGraphCopierTests {
 	}
 
 	@Test def graph_fontname() {
-		//replaceFontAccess("Times New Roman")
+		//mockAvailableFonts("Times New Roman")
 		// This test shows current behaviour, it needs adaptation once the attribute is supported.
 		'''
 			digraph {
@@ -1533,6 +1533,41 @@ class Dot2ZestGraphCopierTests {
 			}
 		''')
 	}
+
+	@Test def cluster_fontname() {
+		mockAvailableFonts("Times New Roman")
+		'''
+			digraph {
+				subgraph clusterName {
+					label="foo"
+					fontname="Times-Bold"
+					1
+				}
+				2
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-external-label : foo
+					element-external-label-css-style : -fx-font-family: "Times New Roman";-fx-font-weight: 700;-fx-font-style: normal;
+					element-label : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node3 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+	
 
 	@Test def graph_fontsize() {
 		// This test shows current behaviour, it needs adaptation once the attribute is supported.
@@ -2547,6 +2582,26 @@ class Dot2ZestGraphCopierTests {
 		'''.assertZestConversion('''
 			Graph {
 				Node1 {
+					element-label : 1
+					element-label-css-style : -fx-font-family: "Arial";-fx-font-weight: 400;-fx-font-style: normal;
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def node_fontname003() {
+		mockAvailableFonts("Arial")
+		'''
+			graph {
+				1[fontname="Helvetica", xlabel="Gotcha"]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-external-label : Gotcha
+					element-external-label-css-style : -fx-font-family: "Arial";-fx-font-weight: 400;-fx-font-style: normal;
 					element-label : 1
 					element-label-css-style : -fx-font-family: "Arial";-fx-font-weight: 400;-fx-font-style: normal;
 					node-shape : GeometryNode

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestAttributesConverter.java
@@ -483,6 +483,15 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 				dotSize);
 	}
 
+	String computeZestGraphLabelCssStyle(Graph dot) {
+		Color dotColor = DotAttributes.getFontcolorParsed(dot);
+		String dotColorScheme = DotAttributes.getColorscheme(dot);
+		FontName dotFont = DotAttributes.getFontnameParsed(dot);
+		Double dotSize = DotAttributes.getFontsizeParsed(dot);
+		return computeZestLabelCssStyle(dotColor, dotColorScheme, dotFont,
+				dotSize);
+	}
+
 	private String computeZestTargetSourceLabelCssStyle(Edge dot) {
 		Color dotColor = DotAttributes.getLabelfontcolorParsed(dot);
 		if (dotColor == null) {

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestGraphCopier.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/Dot2ZestGraphCopier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG and others.
+ * Copyright (c) 2017, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
  * Contributors:
  *    Alexander Nyßen (itemis AG) - initial API and implementation
  *    Tamas Miklossy  (itemis AG) - minor improvements, refactoring
+ *    Zoey Prigge     (itemis AG) - DotGraphView: FontName support (bug #541056)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal.ui;
@@ -114,6 +115,14 @@ public class Dot2ZestGraphCopier extends GraphCopier {
 					bb.getLly() - bb.getUry());
 			ZestProperties.setPosition(zestNode, zestPosition);
 			ZestProperties.setSize(zestNode, zestSize);
+		}
+
+		// label fontcolor, fontsize, fontname
+		String zestNodeLabelCssStyle = getAttributeCopier()
+				.computeZestGraphLabelCssStyle(dotNode.getNestedGraph());
+		if (zestNodeLabelCssStyle != null) {
+			ZestProperties.setExternalLabelCssStyle(zestNode,
+					zestNodeLabelCssStyle);
 		}
 
 		// determine label for cluster

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotContentPartFactory.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotContentPartFactory.java
@@ -1,5 +1,5 @@
 /************************************************************************************************
- * Copyright (c) 2018 itemis AG and others.
+ * Copyright (c) 2018, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Tamas Miklossy (itemis AG) - initial API and implementation (bug #538226)
+ *     Zoey Prigge    (itemis AG) - DotGraphView: FontName support (bug #541056)
  *
  ***********************************************************************************************/
 package org.eclipse.gef.dot.internal.ui;
@@ -21,7 +22,6 @@ import org.eclipse.gef.mvc.fx.parts.IContentPartFactory;
 import org.eclipse.gef.zest.fx.ZestProperties;
 import org.eclipse.gef.zest.fx.parts.EdgePart;
 import org.eclipse.gef.zest.fx.parts.GraphPart;
-import org.eclipse.gef.zest.fx.parts.NodeLabelPart;
 
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -66,7 +66,7 @@ public class DotContentPartFactory implements IContentPartFactory {
 						.getKey() instanceof org.eclipse.gef.graph.Node
 				&& ZestProperties.EXTERNAL_LABEL__NE
 						.equals(((Pair) content).getValue())) {
-			part = new NodeLabelPart();
+			part = new DotNodeLabelPart();
 		}
 		if (part != null) {
 			// TODO: use injector to create parts

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotFontUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotFontUtil.java
@@ -60,9 +60,11 @@ public class DotFontUtil {
 		case LIGHT:
 			return 300;
 		case SEMILIGHT:
-			return 350;
+			// JavaFX does not support 350
+			return 300;
 		case BOOK:
-			return 380;
+			// JavaFX does not support 380
+			return 400;
 		case MEDIUM:
 			return 500;
 		case SEMIBOLD:

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotNodeLabelPart.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotNodeLabelPart.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - initial API and implementation (bug #541056)
+ *     
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.ui;
+
+import java.util.Map;
+
+import org.eclipse.gef.graph.Node;
+import org.eclipse.gef.mvc.fx.parts.IVisualPart;
+import org.eclipse.gef.zest.fx.ZestProperties;
+import org.eclipse.gef.zest.fx.parts.NodeLabelPart;
+
+import javafx.scene.Group;
+
+public class DotNodeLabelPart extends NodeLabelPart {
+	/**
+	 * The implementation of this class is mainly taken from the
+	 * org.eclipse.gef.zest.fx.parts.NodeLabelPart java class.
+	 * 
+	 * Modification added: applying the external label css style on the Text
+	 * widget instead of its parent Group.
+	 */
+	@Override
+	protected void doRefreshVisual(Group visual) {
+		Node node = getContent().getKey();
+		Map<String, Object> attrs = node.attributesProperty();
+
+		if (attrs.containsKey(ZestProperties.EXTERNAL_LABEL_CSS_STYLE__NE)) {
+			String textCssStyle = ZestProperties.getExternalLabelCssStyle(node);
+			getText().setStyle(textCssStyle);
+		}
+
+		String label = ZestProperties.getExternalLabel(node);
+		if (label != null) {
+			getText().setText(label);
+		}
+
+		IVisualPart<? extends javafx.scene.Node> firstAnchorage = getFirstAnchorage();
+		if (firstAnchorage == null) {
+			return;
+		}
+
+		refreshPosition(getVisual(), getLabelPosition());
+	}
+}


### PR DESCRIPTION
-provide additional package public computeZestGraphLabelCssStyle method
in Dot2ZestAttributeConverter
-adopt above method for cluster labels in Dot2ZestGraphCopier
-copy NodeLabelPart to DotNodeLabelPart to change css application for
external labels and register in DotContentPartFactory
-minor change in DotFontUtil to avoid javafx warning
-implement corresponding DotGraphCopierTests

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=541056