### PR TITLE
[541106] Implement Penwidth visualization support

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestEdgeAttributesConversionTests.xtend
@@ -81,6 +81,17 @@ class Dot2ZestEdgeAttributesConversionTests {
 	@Test def edge_style004() {
 		'''
 			graph {
+				1--2 [style=bold penwidth=0.5]
+			}
+		'''.assertEdgeStyle('''
+			-fx-stroke-line-cap: butt;
+			-fx-stroke-width:0.5;
+		''')
+	}
+
+	@Test def edge_style005() {
+		'''
+			graph {
 				1--2 [style=dashed]
 			}
 		'''.assertEdgeStyle('''
@@ -88,7 +99,7 @@ class Dot2ZestEdgeAttributesConversionTests {
 		''')
 	}
 
-	@Test def edge_style005() {
+	@Test def edge_style006() {
 		'''
 			graph {
 				1--2 [style=dotted]
@@ -98,13 +109,38 @@ class Dot2ZestEdgeAttributesConversionTests {
 		''')
 	}
 
-	@Test def edge_style006() {
+	@Test def edge_style007() {
 		'''
 			graph {
 				1--2 [style=solid]
 			}
 		'''.assertEdgeStyle('''
 			-fx-stroke-line-cap: butt;
+		''')
+	}
+	
+	@Test def edge_style008() {
+		'''
+			graph {
+				1--2 [penwidth=3]
+			}
+		'''.assertEdgeStyle('''
+			-fx-stroke-line-cap: butt;
+			-fx-stroke-width:3.0;
+		''')
+	}
+	
+	@Test def edge_style009() {
+		// test css attribute order
+		// -fx-stroke-width needs to follow after -fx-stroke
+		'''
+			graph {
+				1--2 [penwidth=3 color=yellow]
+			}
+		'''.assertEdgeStyle('''
+			-fx-stroke-line-cap: butt;
+			-fx-stroke: #ffff00;
+			-fx-stroke-width:3.0;
 		''')
 	}
 
@@ -157,7 +193,36 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeSourceDecorationStyles('''''', '''
 			-fx-stroke: #00ff00;
+			-fx-fill: #ffffff;
 		''')
+	}
+	
+	@Test def edge_sourceDecorationStyle006() {
+		// test css attribute order
+		// -fx-stroke-width needs to follow after -fx-stroke
+		'''
+			digraph {
+				1->2[dir=both color=green arrowtail=obox penwidth=0.5]
+			}
+		'''.assertEdgeSourceDecorationStyles('''
+			-fx-stroke: #00ff00;
+			-fx-fill: #ffffff;
+			-fx-stroke-width: 0.5;
+		''') 
+	}
+	
+	@Test def edge_sourceDecorationStyle007() {
+		// test css attribute order
+		// -fx-stroke-width needs to follow after -fx-stroke
+		'''
+			digraph {
+				1->2[dir=both arrowtail=normal penwidth=0.5]
+			}
+		'''.assertEdgeSourceDecorationStyles('''
+			-fx-stroke: #000000;
+			-fx-fill: #000000;
+			-fx-stroke-width: 0.5;
+		''') 
 	}
 
 	@Test def edge_targetDecorationStyle001() {
@@ -210,6 +275,35 @@ class Dot2ZestEdgeAttributesConversionTests {
 			}
 		'''.assertEdgeTargetDecorationStyles('''
 			-fx-stroke: #00ff00;
+			-fx-fill: #ffffff;
+		''')
+	}
+	
+	@Test def edge_targetDecorationStyle006() {
+		// test css attribute order
+		// -fx-stroke-width needs to follow after -fx-stroke
+		'''
+			digraph {
+				1->2[color=green arrowhead=onormal penwidth=0.5]
+			}
+		'''.assertEdgeTargetDecorationStyles('''
+			-fx-stroke: #00ff00;
+			-fx-fill: #ffffff;
+			-fx-stroke-width: 0.5;
+		''')
+	}
+
+	@Test def edge_targetDecorationStyle007() {
+		// test css attribute order
+		// -fx-stroke-width needs to follow after -fx-stroke
+		'''
+			digraph {
+				1->2[arrowhead=onormal penwidth=0.5]
+			}
+		'''.assertEdgeTargetDecorationStyles('''
+			-fx-stroke: #000000;
+			-fx-fill: #ffffff;
+			-fx-stroke-width: 0.5;
 		''')
 	}
 

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTests.xtend
@@ -1101,6 +1101,33 @@ class Dot2ZestGraphCopierTests {
 		''')
 	}
 
+	@Test def void edge_penwidth() {
+		// color and style=bold can interfere with penwidth, hence these are tested too.
+		'''
+			digraph {
+				1->2[style=bold penwidth=0.5 color=green]
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Edge1 from Node1 to Node2 {
+					edge-curve : GeometryNode
+					edge-curve-css-style : -fx-stroke-line-cap: butt;-fx-stroke: #00ff00;-fx-stroke-width:0.5;
+					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
+				}
+			}
+		''')
+	}
+
 	@Test def void edge_pos() {
 		// TODO: implement
 	}
@@ -2722,6 +2749,23 @@ class Dot2ZestGraphCopierTests {
 					element-css-id : nodeID
 					element-label : 1
 					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def node_penwidth() {
+		// color and style=bold can interfere with penwidth, hence these are tested too.
+		'''
+			graph {
+				1[penwidth=4 style=bold color="green"]
+			}
+		'''.assertZestConversion(new NodeShapeWithStylePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0), style: -fx-stroke: #00ff00;-fx-stroke-width:4.0;
 					node-size : Dimension(54.0, 36.0)
 				}
 			}

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTests.xtend
@@ -392,6 +392,26 @@ class Dot2ZestNodeAttributesConversionTests {
 		'''.assertNodeXLabel("node:1 graph:testedGraphName")
 	}
 
+	@Test def node_penwidth001() {
+		'''
+			digraph{
+				1[style=bold, penwidth=3]
+			}
+		'''.assertNodeStyle('''
+			-fx-stroke-width:3.0;
+		''')
+	}
+	
+	@Test def node_penwidth002() {
+		'''
+			digraph{
+				1[penwidth=0.5]
+			}
+		'''.assertNodeStyle('''
+			-fx-stroke-width:0.5;
+		''')
+	}
+
 	@Test def node_polygonbasedshape001() { 
 		'''
 			digraph {


### PR DESCRIPTION
-Implement penwidth visualisation support for nodes and edges (including
decorations) in Dot2ZestAttributesConverter 
-include penwidth in DotArrowShapeDecorations methods
-refactor setOpen in DotArrowShapeDecorations to reuse setStroke method
-implement/adapt corresponding test cases


Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=541106