### PR TITLE
[546593]: Immediately refresh the marquee feedback on creation

### DIFF
--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/handlers/MarqueeOnDragHandler.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/handlers/MarqueeOnDragHandler.java
@@ -193,6 +193,7 @@ public class MarqueeOnDragHandler extends AbstractHandler
 			}
 		};
 		getHost().getRoot().addChildren(Collections.singletonList(feedback));
+		feedback.refreshVisual();
 	}
 
 	@Override


### PR DESCRIPTION
- After creating the MarqueeSelectionFeedback, immediately refresh it to make sure it is located under the mouse, so scrollbars won't have to be displayed if they're not necessary