### PR TITLE
[530658] Add Zest support for edges tooltips.

### DIFF
--- a/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/ZestProperties.java
+++ b/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/ZestProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG and others.
+ * Copyright (c) 2015, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
  * Contributors:
  *     Matthias Wienand (itemis AG) - initial API & implementation
  *     Tamas Miklossy   (itemis AG) - documentation improvements
+ *                                  - edge tooltip support (bug #530658)
  *
  *******************************************************************************/
 package org.eclipse.gef.zest.fx;
@@ -270,6 +271,58 @@ public class ZestProperties {
 	 * @see #setTooltip(Node, String)
 	 */
 	public static final String TOOLTIP__N = "node-tooltip";
+
+	/**
+	 * This attribute determines the tooltip for an edge. This attribute does not
+	 * have a default value.
+	 *
+	 * @see #getTooltip(Edge)
+	 * @see #setTooltip(Edge, String)
+	 * @since 5.1
+	 */
+	public static final String TOOLTIP__E = "edge-tooltip";
+
+	/**
+	 * This attribute determines the tooltip for an edge label. This attribute does
+	 * not have a default value.
+	 *
+	 * @see #getLabelTooltip(Edge)
+	 * @see #setLabelTooltip(Edge, String)
+	 * @since 5.1
+	 */
+	public static final String LABEL_TOOLTIP__E = "edge-label-tooltip";
+
+	/**
+	 * This attribute determines the tooltip for an edge source label. This attribute does
+	 * not have a default value.
+	 *
+	 * @see #getSourceLabelTooltip(Edge)
+	 * @see #setSourceLabelTooltip(Edge, String)
+	 * @since 5.1
+	 */
+	public static final String SOURCE_LABEL_TOOLTIP__E = "edge-source-label-tooltip";
+
+	/**
+	 * This attribute determines the tooltip for an edge target label. This attribute does
+	 * not have a default value.
+	 *
+	 * @see #getTargetLabelTooltip(Edge)
+	 * @see #setTargetLabelTooltip(Edge, String)
+	 * @since 5.1
+	 */
+	public static final String TARGET_LABEL_TOOLTIP__E = "edge-target-label-tooltip";
+
+	/**
+	 * This attribute determines the tooltip for an element (node/edge) external label. This attribute does
+	 * not have a default value.
+	 *
+	 * @see #getExternalLabelTooltip(Edge)
+	 * @see #getExternalLabelTooltip(Node)
+	 * @see #setExternalLabelTooltip(Edge, String)
+	 * @see #setExternalLabelTooltip(Node, String)
+	 * @since 5.1
+	 */
+	public static final String EXTERNAL_LABEL_TOOLTIP__NE = "element-external-label-tooltip";
 
 	/**
 	 * This attribute determines the target decoration for an edge. This
@@ -566,6 +619,44 @@ public class ZestProperties {
 	}
 
 	/**
+	 * Returns the value of the {@link #EXTERNAL_LABEL_TOOLTIP__NE} attribute of the given
+	 * {@link Edge}.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the external label tooltip is determined.
+	 * @return The tooltip of the given {@link Edge} external label. If a {@link Provider} is
+	 *         set for {@link #EXTERNAL_LABEL_TOOLTIP__NE}, the value will be retrieved from it
+	 *         using {@link Provider#get()}.
+	 * @since 5.1
+	 */
+	public static String getExternalLabelTooltip(Edge edge) {
+		Object value = edge.attributesProperty().get(EXTERNAL_LABEL_TOOLTIP__NE);
+		if (value instanceof Provider) {
+			return (String) ((Provider<?>) value).get();
+		}
+		return (String) value;
+	}
+
+	/**
+	 * Returns the value of the {@link #EXTERNAL_LABEL_TOOLTIP__NE} attribute of the given
+	 * {@link Node}.
+	 *
+	 * @param node
+	 *            The {@link Node} of which the external label tooltip is determined.
+	 * @return The tooltip of the given {@link Node} extrnal label. If a {@link Provider} is
+	 *         set for {@link #EXTERNAL_LABEL_TOOLTIP__NE}, the value will be retrieved from it
+	 *         using {@link Provider#get()}.
+	 * @since 5.1
+	 */
+	public static String getExternalLabelTooltip(Node node) {
+		Object value = node.attributesProperty().get(EXTERNAL_LABEL_TOOLTIP__NE);
+		if (value instanceof Provider) {
+			return (String) ((Provider<?>) value).get();
+		}
+		return (String) value;
+	}
+
+	/**
 	 * Returns the value of the {@link #ICON__N} attribute of the given
 	 * {@link Node}.
 	 *
@@ -716,6 +807,25 @@ public class ZestProperties {
 			return (Point) ((Provider<?>) value).get();
 		}
 		return (Point) value;
+	}
+
+	/**
+	 * Returns the value of the {@link #LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge}.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the label tooltip is determined.
+	 * @return The tooltip of the given {@link Edge} label. If a {@link Provider} is
+	 *         set for {@link #LABEL_TOOLTIP__E}, the value will be retrieved from it
+	 *         using {@link Provider#get()}.
+	 * @since 5.1
+	 */
+	public static String getLabelTooltip(Edge edge) {
+		Object value = edge.attributesProperty().get(LABEL_TOOLTIP__E);
+		if (value instanceof Provider) {
+			return (String) ((Provider<?>) value).get();
+		}
+		return (String) value;
 	}
 
 	/**
@@ -940,6 +1050,25 @@ public class ZestProperties {
 	}
 
 	/**
+	 * Returns the value of the {@link #SOURCE_LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge}.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the source label tooltip is determined.
+	 * @return The tooltip of the given {@link Edge} source label. If a {@link Provider} is
+	 *         set for {@link #SOURCE_LABEL_TOOLTIP__E}, the value will be retrieved from it
+	 *         using {@link Provider#get()}.
+	 * @since 5.1
+	 */
+	public static String getSourceLabelTooltip(Edge edge) {
+		Object value = edge.attributesProperty().get(SOURCE_LABEL_TOOLTIP__E);
+		if (value instanceof Provider) {
+			return (String) ((Provider<?>) value).get();
+		}
+		return (String) value;
+	}
+
+	/**
 	 * Returns the value of the {@link #START_POINT__E} attribute of the given
 	 * {@link Edge}.
 	 *
@@ -1041,6 +1170,25 @@ public class ZestProperties {
 		}
 		return (Point) value;
 	}
+	
+	/**
+	 * Returns the value of the {@link #TARGET_LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge}.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the target label tooltip is determined.
+	 * @return The tooltip of the given {@link Edge} target label. If a {@link Provider} is
+	 *         set for {@link #TARGET_LABEL_TOOLTIP__E}, the value will be retrieved from it
+	 *         using {@link Provider#get()}.
+	 * @since 5.1
+	 */
+	public static String getTargetLabelTooltip(Edge edge) {
+		Object value = edge.attributesProperty().get(TARGET_LABEL_TOOLTIP__E);
+		if (value instanceof Provider) {
+			return (String) ((Provider<?>) value).get();
+		}
+		return (String) value;
+	}
 
 	/**
 	 * Returns the value of the {@link #TOOLTIP__N} attribute of the given
@@ -1054,6 +1202,25 @@ public class ZestProperties {
 	 */
 	public static String getTooltip(Node node) {
 		Object value = node.attributesProperty().get(TOOLTIP__N);
+		if (value instanceof Provider) {
+			return (String) ((Provider<?>) value).get();
+		}
+		return (String) value;
+	}
+
+	/**
+	 * Returns the value of the {@link #TOOLTIP__E} attribute of the given
+	 * {@link Edge}.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the tooltip is determined.
+	 * @return The tooltip of the given {@link Edge}. If a {@link Provider} is
+	 *         set for {@link #TOOLTIP__E}, the value will be retrieved from it
+	 *         using {@link Provider#get()}.
+	 * @since 5.1
+	 */
+	public static String getTooltip(Edge edge) {
+		Object value = edge.attributesProperty().get(TOOLTIP__E);
 		if (value instanceof Provider) {
 			return (String) ((Provider<?>) value).get();
 		}
@@ -1553,6 +1720,80 @@ public class ZestProperties {
 	}
 
 	/**
+	 * Sets the value of the {@link #EXTERNAL_LABEL_TOOLTIP__NE} attribute of the given
+	 * {@link Node} to the given provider.
+	 *
+	 * @param node
+	 *            The {@link Node} whose attribute is change.
+	 * @param tooltipProvider
+	 *            A {@link Provider} which is used to retrieve the
+	 *            {@link #EXTERNAL_LABEL_TOOLTIP__NE} value.
+	 * @since 5.1
+	 */
+	public static void setExternalLabelTooltip(Node node, Provider<String> tooltipProvider) {
+		if (tooltipProvider == null) {
+			node.attributesProperty().remove(EXTERNAL_LABEL_TOOLTIP__NE);
+		} else {
+			node.attributesProperty().put(EXTERNAL_LABEL_TOOLTIP__NE, tooltipProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #EXTERNAL_LABEL_TOOLTIP__NE} attribute of the given
+	 * {@link Node} to the given value.
+	 *
+	 * @param node
+	 *            The {@link Node} of which the external label tooltip is changed.
+	 * @param tooltip
+	 *            The new tooltip for the given {@link Node}'s external label.
+	 * @since 5.1
+	 */
+	public static void setExternalLabelTooltip(Node node, String tooltip) {
+		if (tooltip == null) {
+			node.attributesProperty().remove(EXTERNAL_LABEL_TOOLTIP__NE);
+		} else {
+			node.attributesProperty().put(EXTERNAL_LABEL_TOOLTIP__NE, tooltip);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #EXTERNAL_LABEL_TOOLTIP__NE} attribute of the given
+	 * {@link Edge} to the given provider.
+	 *
+	 * @param edge
+	 *            The {@link Edge} whose attribute is change.
+	 * @param tooltipProvider
+	 *            A {@link Provider} which is used to retrieve the
+	 *            {@link #EXTERNAL_LABEL_TOOLTIP__NE} value.
+	 * @since 5.1
+	 */
+	public static void setExternalLabelTooltip(Edge edge, Provider<String> tooltipProvider) {
+		if (tooltipProvider == null) {
+			edge.attributesProperty().remove(EXTERNAL_LABEL_TOOLTIP__NE);
+		} else {
+			edge.attributesProperty().put(EXTERNAL_LABEL_TOOLTIP__NE, tooltipProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #EXTERNAL_LABEL_TOOLTIP__NE} attribute of the given
+	 * {@link Edge} to the given value.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the external label tooltip is changed.
+	 * @param tooltip
+	 *            The new external label tooltip for the given {@link Edge}.
+	 * @since 5.1
+	 */
+	public static void setExternalLabelTooltip(Edge edge, String tooltip) {
+		if (tooltip == null) {
+			edge.attributesProperty().remove(EXTERNAL_LABEL_TOOLTIP__NE);
+		} else {
+			edge.attributesProperty().put(EXTERNAL_LABEL_TOOLTIP__NE, tooltip);
+		}
+	}
+
+	/**
 	 * Sets the value of the {@link #ICON__N} attribute of the given
 	 * {@link Node} to the given value.
 	 *
@@ -1867,6 +2108,43 @@ public class ZestProperties {
 			edge.getAttributes().remove(LABEL_POSITION__E);
 		} else {
 			edge.attributesProperty().put(LABEL_POSITION__E, labelPositionProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given provider.
+	 *
+	 * @param edge
+	 *            The {@link Edge} whose attribute is change.
+	 * @param tooltipProvider
+	 *            A {@link Provider} which is used to retrieve the
+	 *            {@link #LABEL_TOOLTIP__E} value.
+	 * @since 5.1
+	 */
+	public static void setLabelTooltip(Edge edge, Provider<String> tooltipProvider) {
+		if (tooltipProvider == null) {
+			edge.attributesProperty().remove(LABEL_TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(LABEL_TOOLTIP__E, tooltipProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given value.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the label tooltip is changed.
+	 * @param tooltip
+	 *            The new tooltip for the given {@link Edge} label.
+	 * @since 5.1
+	 */
+	public static void setLabelTooltip(Edge edge, String tooltip) {
+		if (tooltip == null) {
+			edge.attributesProperty().remove(LABEL_TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(LABEL_TOOLTIP__E, tooltip);
 		}
 	}
 
@@ -2332,6 +2610,43 @@ public class ZestProperties {
 	}
 
 	/**
+	 * Sets the value of the {@link #SOURCE_LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given provider.
+	 *
+	 * @param edge
+	 *            The {@link Edge} whose attribute is change.
+	 * @param tooltipProvider
+	 *            A {@link Provider} which is used to retrieve the
+	 *            {@link #SOURCE_LABEL_TOOLTIP__E} value.
+	 * @since 5.1
+	 */
+	public static void setSourceLabelTooltip(Edge edge, Provider<String> tooltipProvider) {
+		if (tooltipProvider == null) {
+			edge.attributesProperty().remove(SOURCE_LABEL_TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(SOURCE_LABEL_TOOLTIP__E, tooltipProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #SOURCE_LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given value.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the source label tooltip is changed.
+	 * @param tooltip
+	 *            The new tooltip for the given {@link Edge} source label.
+	 * @since 5.1
+	 */
+	public static void setSourceLabelTooltip(Edge edge, String tooltip) {
+		if (tooltip == null) {
+			edge.attributesProperty().remove(SOURCE_LABEL_TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(SOURCE_LABEL_TOOLTIP__E, tooltip);
+		}
+	}
+
+	/**
 	 * Sets the value of the {@link #START_POINT__E} attribute of the given
 	 * {@link Edge} to the given value.
 	 *
@@ -2547,6 +2862,43 @@ public class ZestProperties {
 	}
 
 	/**
+	 * Sets the value of the {@link #TARGET_LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given provider.
+	 *
+	 * @param edge
+	 *            The {@link Edge} whose attribute is change.
+	 * @param tooltipProvider
+	 *            A {@link Provider} which is used to retrieve the
+	 *            {@link #TARGET_LABEL_TOOLTIP__E} value.
+	 * @since 5.1
+	 */
+	public static void setTargetLabelTooltip(Edge edge, Provider<String> tooltipProvider) {
+		if (tooltipProvider == null) {
+			edge.attributesProperty().remove(TARGET_LABEL_TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(TARGET_LABEL_TOOLTIP__E, tooltipProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #TARGET_LABEL_TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given value.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the target label tooltip is changed.
+	 * @param tooltip
+	 *            The new tooltip for the given {@link Edge} target label.
+	 * @since 5.1
+	 */
+	public static void setTargetLabelTooltip(Edge edge, String tooltip) {
+		if (tooltip == null) {
+			edge.attributesProperty().remove(TARGET_LABEL_TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(TARGET_LABEL_TOOLTIP__E, tooltip);
+		}
+	}
+
+	/**
 	 * Sets the value of the {@link #TOOLTIP__N} attribute of the given
 	 * {@link Node} to the given provider.
 	 *
@@ -2578,6 +2930,43 @@ public class ZestProperties {
 			node.attributesProperty().remove(TOOLTIP__N);
 		} else {
 			node.attributesProperty().put(TOOLTIP__N, tooltip);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given provider.
+	 *
+	 * @param edge
+	 *            The {@link Edge} whose attribute is change.
+	 * @param tooltipProvider
+	 *            A {@link Provider} which is used to retrieve the
+	 *            {@link #TOOLTIP__E} value.
+	 * @since 5.1
+	 */
+	public static void setTooltip(Edge edge, Provider<String> tooltipProvider) {
+		if (tooltipProvider == null) {
+			edge.attributesProperty().remove(TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(TOOLTIP__E, tooltipProvider);
+		}
+	}
+
+	/**
+	 * Sets the value of the {@link #TOOLTIP__E} attribute of the given
+	 * {@link Edge} to the given value.
+	 *
+	 * @param edge
+	 *            The {@link Edge} of which the tooltip is changed.
+	 * @param tooltip
+	 *            The new tooltip for the given {@link Edge}.
+	 * @since 5.1
+	 */
+	public static void setTooltip(Edge edge, String tooltip) {
+		if (tooltip == null) {
+			edge.attributesProperty().remove(TOOLTIP__E);
+		} else {
+			edge.attributesProperty().put(TOOLTIP__E, tooltip);
 		}
 	}
 }

--- a/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/parts/EdgeLabelPart.java
+++ b/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/parts/EdgeLabelPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG and others.
+ * Copyright (c) 2015, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Matthias Wienand (itemis AG) - initial API & implementation
+ *     Tamas Miklossy   (itemis AG) - edge tooltip support (bug #530658)
  *
  *******************************************************************************/
 package org.eclipse.gef.zest.fx.parts;
@@ -26,6 +27,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 
 import javafx.scene.Group;
+import javafx.scene.control.Tooltip;
 import javafx.scene.text.Text;
 import javafx.util.Pair;
 
@@ -37,6 +39,19 @@ import javafx.util.Pair;
  *
  */
 public class EdgeLabelPart extends AbstractLabelPart {
+	/**
+	 * Array containing the {@link Tooltip} nodes of this {@link EdgeLabelPart} in
+	 * the following order:
+	 * <ul>
+	 * <li>[0]: tooltip node on the label of the edge.
+	 * <li>[1]: tooltip node on the source label of the edge.
+	 * <li>[2]: tootlip node on the target label of the edge.
+	 * <li>[3]: tooltip node on the external label of the edge.
+	 * </ul>
+	 *
+	 * @since 5.1
+	 */
+	protected Tooltip[] tooltipNodes = new Tooltip[4];
 
 	@Override
 	public Point computeLabelPosition() {
@@ -120,6 +135,8 @@ public class EdgeLabelPart extends AbstractLabelPart {
 		}
 
 		refreshPosition(getVisual(), getLabelPosition());
+
+		refreshTooltip();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -185,5 +202,54 @@ public class EdgeLabelPart extends AbstractLabelPart {
 		}
 		return NodeUtils.sceneToLocal(getVisual().getParent(),
 				NodeUtils.localToScene(connection, startPoint.getTranslated(v.x, v.y)));
+	}
+
+	/**
+	 * Changes the tooltip of this {@link EdgeLabelPart} to the given value.
+	 *
+	 * @since 5.1
+	 */
+	protected void refreshTooltip() {
+		Pair<Edge, String> content = getContent();
+		Edge edge = content.getKey();
+		String zestProperty = content.getValue();
+		switch (zestProperty) {
+		case ZestProperties.LABEL__NE:
+			refreshTooltip(tooltipNodes[0], ZestProperties.getLabelTooltip(edge));
+			break;
+		case ZestProperties.SOURCE_LABEL__E:
+			refreshTooltip(tooltipNodes[1], ZestProperties.getSourceLabelTooltip(edge));
+			break;
+		case ZestProperties.TARGET_LABEL__E:
+			refreshTooltip(tooltipNodes[2], ZestProperties.getTargetLabelTooltip(edge));
+			break;
+		case ZestProperties.EXTERNAL_LABEL__NE:
+			refreshTooltip(tooltipNodes[3], ZestProperties.getExternalLabelTooltip(edge));
+			break;
+		default:
+			break;
+		}
+	}
+
+	/**
+	 * Changes the tooltip of this {@link EdgeLabelPart} to the given value.
+	 *
+	 * @param tooltipNode the tooltip node
+	 * @param tooltip     the tooltip text
+	 * @since 5.1
+	 */
+	protected void refreshTooltip(Tooltip tooltipNode, String tooltip) {
+		if (tooltip != null && !tooltip.isEmpty()) {
+			if (tooltipNode == null) {
+				tooltipNode = new Tooltip(tooltip);
+				Tooltip.install(getVisual(), tooltipNode);
+			} else {
+				tooltipNode.setText(tooltip);
+			}
+		} else {
+			if (tooltipNode != null) {
+				Tooltip.uninstall(getVisual(), tooltipNode);
+			}
+		}
 	}
 }

--- a/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/parts/EdgePart.java
+++ b/org.eclipse.gef.zest.fx/src/org/eclipse/gef/zest/fx/parts/EdgePart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 itemis AG and others.
+ * Copyright (c) 2014, 2019 itemis AG and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Matthias Wienand (itemis AG) - initial API & implementation
+ *     Tamas Miklossy   (itemis AG) - edge tooltip support (bug #530658)
  *
  *******************************************************************************/
 package org.eclipse.gef.zest.fx.parts;
@@ -35,6 +36,7 @@ import com.google.common.collect.SetMultimap;
 
 import javafx.collections.MapChangeListener;
 import javafx.scene.Node;
+import javafx.scene.control.Tooltip;
 
 /**
  * The {@link EdgePart} is the controller for an {@link Edge} content object. It
@@ -60,6 +62,8 @@ public class EdgePart extends AbstractContentPart<Connection> implements IBendab
 	 * CSS class assigned to the decorations.
 	 */
 	public static final String CSS_CLASS_DECORATION = "decoration";
+
+	private Tooltip tooltipNode;
 
 	private MapChangeListener<String, Object> edgeAttributesObserver = new MapChangeListener<String, Object>() {
 
@@ -285,6 +289,8 @@ public class EdgePart extends AbstractContentPart<Connection> implements IBendab
 		if (!visual.getControlPoints().equals(controlPoints)) {
 			visual.setControlPoints(controlPoints);
 		}
+
+		refreshTooltip();
 	}
 
 	@Override
@@ -348,6 +354,28 @@ public class EdgePart extends AbstractContentPart<Connection> implements IBendab
 			getVisual().setCurve(curve);
 			if (!curve.getStyleClass().contains(CSS_CLASS_CURVE)) {
 				curve.getStyleClass().add(CSS_CLASS_CURVE);
+			}
+		}
+	}
+
+	/**
+	 * Changes the tooltip of this {@link EdgePart} to the given value.
+	 *
+	 * @since 5.1
+	 *
+	 */
+	protected void refreshTooltip() {
+		String tooltip = ZestProperties.getTooltip(getContent());
+		if (tooltip != null && !tooltip.isEmpty()) {
+			if (tooltipNode == null) {
+				tooltipNode = new Tooltip(tooltip);
+				Tooltip.install(getVisual(), tooltipNode);
+			} else {
+				tooltipNode.setText(tooltip);
+			}
+		} else {
+			if (tooltipNode != null) {
+				Tooltip.uninstall(getVisual(), tooltipNode);
 			}
 		}
 	}


### PR DESCRIPTION
- edge-tooltip
- edge-label-tooltip
- edge-source-label-tooltip
- edge-target-label-tooltip
- element-external-label-tooltip

https://bugs.eclipse.org/bugs/show_bug.cgi?id=530658