### PR TITLE
Removed final-modifier to allow override of this method. The add-Method

### DIFF
--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
@@ -99,7 +99,7 @@ public abstract class AbstractContentPart<V extends Node>
 	 * overwritten by subclasses.
 	 */
 	@Override
-	public final void addContentChild(Object contentChild, int index) {
+	public void addContentChild(Object contentChild, int index) {
 		List<Object> oldContentChildren = new ArrayList<>(
 				doGetContentChildren());
 		if (oldContentChildren.contains(contentChild)) {

--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 itemis AG and others.
+ * Copyright (c) 2014, 2019 itemis AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Removed final-modifier to allow override of this method. The add-Method
checks the Position of the new added content child and throws a
IllegalStateException if the index is not the same index as before. If
you have to sort your items in case of "visual-layer-issues"(Shapes should be in Front of others...) you will
have a lot of problems and a lot of code to have a workaround and avoid
this IllegalStateException.



