### PR TITLE
Bugfix: Gestures have problems with changing scenes

### DIFF
--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/gestures/ClickDragGesture.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/gestures/ClickDragGesture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 itemis AG and others.
+ * Copyright (c) 2014, 2019 itemis AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
  * Contributors:
  *     Matthias Wienand (itemis AG) - initial API and implementation
  *     Alexander Nyßen (itemis AG) - refactorings
+ *     Shawn Kleese (IT.UV Software GmbH - bugfixing)
  *
  *******************************************************************************/
 package org.eclipse.gef.mvc.fx.gestures;
@@ -39,6 +40,7 @@ import javafx.event.EventTarget;
 import javafx.event.EventType;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
@@ -279,6 +281,21 @@ public class ClickDragGesture extends AbstractGesture {
 			if (sceneProperty.get() != null) {
 				sceneListener.changed(sceneProperty, null, sceneProperty.get());
 			}
+
+			// register on every Viewers-Canvas scene-Property a Change-Listener
+			// to detect Scene-Changes. For example: Detaching Viewparts
+			Parent canvas = viewer.getCanvas();
+			canvas.sceneProperty().addListener((obs, ov, nv) -> {
+
+				if ((ov != null)) {
+					unhookScene(ov);
+				}
+
+				if ((nv != null)) {
+					hookScene(nv);
+				}
+			});
+
 		}
 	}
 

--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/gestures/HoverGesture.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/gestures/HoverGesture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 itemis AG and others.
+ * Copyright (c) 2014, 2019 itemis AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     Matthias Wienand (itemis AG) - initial API and implementation
+ *     Shawn Kleese (IT.UV Software GmbH) - bugfixing
  *
  *******************************************************************************/
 package org.eclipse.gef.mvc.fx.gestures;
@@ -27,6 +28,7 @@ import javafx.beans.value.ChangeListener;
 import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Duration;
@@ -131,6 +133,21 @@ public class HoverGesture extends AbstractGesture {
 			if (sceneProperty.get() != null) {
 				sceneListener.changed(sceneProperty, null, sceneProperty.get());
 			}
+
+			// register on every Viewers-Canvas scene-Property a Change-Listener
+			// to detect Scene-Changes. For example: Detaching Viewparts
+			Parent canvas = viewer.getCanvas();
+			canvas.sceneProperty().addListener((obs, ov, nv) -> {
+
+				if ((ov != null)) {
+					unhookScene(ov);
+				}
+
+				if ((nv != null)) {
+					hookScene(nv);
+				}
+			});
+
 		}
 	}
 
@@ -247,6 +264,9 @@ public class HoverGesture extends AbstractGesture {
 	}
 
 	private void unhookScene(Scene scene) {
+		if (!hoverFilters.containsKey(scene)) {
+			return;
+		}
 		scene.removeEventFilter(MouseEvent.ANY, hoverFilters.remove(scene));
 	}
 

--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/gestures/TypeStrokeGesture.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/gestures/TypeStrokeGesture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 itemis AG and others.
+ * Copyright (c) 2014, 2019 itemis AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     Matthias Wienand (itemis AG) - initial API and implementation
+ *     Shawn Kleese (IT.UV Software GmbH) - bugfixing
  *
  *******************************************************************************/
 package org.eclipse.gef.mvc.fx.gestures;
@@ -30,6 +31,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -130,6 +132,21 @@ public class TypeStrokeGesture extends AbstractGesture {
 			if (sceneProperty.get() != null) {
 				sceneListener.changed(sceneProperty, null, sceneProperty.get());
 			}
+
+			// register on every Viewers-Canvas scene-Property a Change-Listener
+			// to detect Scene-Changes. For example: Detaching Viewparts
+			Parent canvas = viewer.getCanvas();
+			canvas.sceneProperty().addListener((obs, ov, nv) -> {
+
+				if ((ov != null)) {
+					unhookScene(ov);
+				}
+
+				if ((nv != null)) {
+					hookScene(nv, pressedKeys);
+				}
+			});
+
 		}
 	}
 

--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
@@ -99,7 +99,7 @@ public abstract class AbstractContentPart<V extends Node>
 	 * overwritten by subclasses.
 	 */
 	@Override
-	public final void addContentChild(Object contentChild, int index) {
+	public void addContentChild(Object contentChild, int index) {
 		List<Object> oldContentChildren = new ArrayList<>(
 				doGetContentChildren());
 		if (oldContentChildren.contains(contentChild)) {

--- a/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
+++ b/org.eclipse.gef.mvc.fx/src/org/eclipse/gef/mvc/fx/parts/AbstractContentPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 itemis AG and others.
+ * Copyright (c) 2014, 2019 itemis AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Register on every Viewers-Canvas scene-Property a Change-Listener
to detect Scene-Changes and unhook listeners and hookink to new Scene.
This happens for example on detaching Viewparts in eclipse RCP Applications