### PR TITLE
[530644] Rebase Dot2ZestAttributeConverter to extract style conversion

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTest.xtend
@@ -2811,7 +2811,7 @@ class Dot2ZestGraphCopierTest {
 				Node1 {
 					element-label-css-style : -fx-font-size: 25.0;
 					VBox {
-						style : -fx-border-color: #00ff00;-fx-border-style:solid;
+						style : -fx-border-color:#00ff00;-fx-border-style:solid;
 						HBox {
 							VBox {
 								HBox {
@@ -2822,7 +2822,7 @@ class Dot2ZestGraphCopierTest {
 								}
 							}
 							RecordBasedLabelLine {
-								style : -fx-stroke: #00ff00;
+								style : -fx-stroke:#00ff00;
 							}
 							VBox {
 								HBox {
@@ -2834,7 +2834,7 @@ class Dot2ZestGraphCopierTest {
 							}
 						}
 						RecordBasedLabelLine {
-							style : -fx-stroke: #00ff00;
+							style : -fx-stroke:#00ff00;
 						}
 						VBox {
 							HBox {
@@ -2845,7 +2845,7 @@ class Dot2ZestGraphCopierTest {
 							}
 						}
 						RecordBasedLabelLine {
-							style : -fx-stroke: #00ff00;
+							style : -fx-stroke:#00ff00;
 						}
 						VBox {
 							HBox {
@@ -2861,7 +2861,7 @@ class Dot2ZestGraphCopierTest {
 				Node2 {
 					element-label-css-style : -fx-font-size: 25.0;
 					VBox {
-						style : -fx-border-color: #00ff00;-fx-background-radius:10px;-fx-border-radius:10px;-fx-border-style:solid;
+						style : -fx-border-color:#00ff00;-fx-background-radius:10px;-fx-border-radius:10px;-fx-border-style:solid;
 						VBox {
 							HBox {
 								Text {
@@ -2871,7 +2871,7 @@ class Dot2ZestGraphCopierTest {
 							}
 						}
 						RecordBasedLabelLine {
-							style : -fx-stroke: #00ff00;
+							style : -fx-stroke:#00ff00;
 						}
 						VBox {
 							HBox {
@@ -2909,7 +2909,7 @@ class Dot2ZestGraphCopierTest {
 				}
 				Node4 {
 					VBox {
-						style : -fx-border-width: 2;-fx-border-style:solid;
+						style : -fx-border-width:2;-fx-border-style:solid;
 						VBox {
 							HBox {
 								Text {
@@ -2932,7 +2932,7 @@ class Dot2ZestGraphCopierTest {
 				}
 				Node5 {
 					VBox {
-						style : -fx-background-color: #ff0000;-fx-border-style:solid;
+						style : -fx-background-color:#ff0000;-fx-border-style:solid;
 						VBox {
 							HBox {
 								Text {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTest.xtend
@@ -741,7 +741,7 @@ class Dot2ZestNodeAttributesConversionTest {
 				1[shape="record",color=red]
 			}
 		'''.assertNodeStyle('''
-			-fx-border-color: #ff0000;
+			-fx-border-color:#ff0000;
 			-fx-border-style:solid;
 		''')
 	}
@@ -753,7 +753,7 @@ class Dot2ZestNodeAttributesConversionTest {
 				1[shape="record",style=bold]
 			}
 		'''.assertNodeStyle('''
-			-fx-border-width: 2;
+			-fx-border-width:2;
 			-fx-border-style:solid;
 		''')
 	}
@@ -798,18 +798,20 @@ class Dot2ZestNodeAttributesConversionTest {
 				1[shape="record" style="rounded, filled" fillcolor=green]
 			}
 		'''.assertNodeStyle('''
-			-fx-background-color: #00ff00;
+			-fx-background-color:#00ff00;
 			-fx-border-style:solid;
 		''')
 	}
 
-	@Ignore("NPE thrown")
+	@Ignore("Failing on Travis/Jenkins")
 	@Test def node_style_record008() {
 		'''
 			digraph {
 				1[shape="record",style="setlinewidth(2)"]
 			}
-		'''.assertNodeStyle("")
+		'''.assertNodeStyle('''
+			-fx-border-style:solid;
+		''')
 	}
 
 	@Ignore("Failing on Travis/Jenkins")

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotDefaultNodeStyleUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotDefaultNodeStyleUtil.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - original implementation, refactoring and initial API
+ *     Tamas Miklossy     (itemis AG) - original implementation
+ *     Matthias Wienand   (itemis AG) - original implementation
+ *
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.ui.conversion;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.dot.internal.DotAttributes;
+import org.eclipse.gef.dot.internal.language.color.Color;
+import org.eclipse.gef.dot.internal.language.color.DotColors;
+import org.eclipse.gef.dot.internal.language.colorlist.ColorList;
+import org.eclipse.gef.dot.internal.language.shape.PolygonBasedNodeShape;
+import org.eclipse.gef.dot.internal.language.shape.PolygonBasedShape;
+import org.eclipse.gef.dot.internal.language.shape.Shape;
+import org.eclipse.gef.dot.internal.language.style.NodeStyle;
+import org.eclipse.gef.dot.internal.language.style.Style;
+import org.eclipse.gef.dot.internal.language.style.StyleItem;
+import org.eclipse.gef.graph.Node;
+
+public class DotDefaultNodeStyleUtil implements DotNodeStyleUtil {
+
+	protected final DotColorUtil colorUtil;
+	protected final Node dot;
+
+	public DotDefaultNodeStyleUtil(DotColorUtil colorUtil, Node dot) {
+		this.colorUtil = colorUtil;
+		this.dot = dot;
+	}
+
+	@Override
+	public StringBuilder computeZestStyle() {
+		StringBuilder zestStyle = new StringBuilder();
+
+		// color
+		Color dotColor = colorAttribute();
+		String dotColorScheme = colorschemeAttribute();
+		String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
+				dotColor);
+		// penwidth
+		Double penwidth = penwidthAttribute();
+
+		if (isNoneShape(shapeAttribute())) {
+			zestStyle.append("-fx-stroke: none;"); //$NON-NLS-1$
+		} else {
+			if (javaFxColor != null) {
+				zestStyle.append(strokeColorFxCssString()); // $NON-NLS-1$
+				zestStyle.append(javaFxColor);
+				zestStyle.append(";"); //$NON-NLS-1$
+			}
+
+			if (penwidth != null) {
+				zestStyle.append(strokeWidthFxCssString()); // $NON-NLS-1$
+				zestStyle.append(penwidth);
+				zestStyle.append(";"); //$NON-NLS-1$
+			}
+		}
+
+		// style
+		Style style = styleAttribute();
+		if (style != null) {
+			for (StyleItem styleItem : style.getStyleItems()) {
+				NodeStyle nodeStyle = NodeStyle.get(styleItem.getName());
+				if (nodeStyle != null) {
+					addNodeStyle(zestStyle, nodeStyle, penwidth == null);
+				}
+			}
+		}
+
+		// fillcolor: evaluate only if the node style is set to 'filled'.
+		if (hasStyle(NodeStyle.FILLED)) {
+			Color dotFillColor = null;
+			ColorList fillColor = fillcolorAttribute();
+			if (fillColor != null && !fillColor.getColorValues().isEmpty()) {
+				// TODO: add support for colorList
+				dotFillColor = fillColor.getColorValues().get(0).getColor();
+			} else {
+				// if the style is filled, but fillcolor is not specified, use
+				// the color attribute value. If neither the fillcolor nor the
+				// color attribute is specified, used the default value.
+				dotFillColor = dotColor != null ? dotColor
+						: DotColors.getDefaultNodeFillColor();
+			}
+			String javaFxFillColor = colorUtil.computeZestColor(dotColorScheme,
+					dotFillColor);
+			if (javaFxFillColor != null) {
+				zestStyle.append(fillFxCssString() + javaFxFillColor + ";"); //$NON-NLS-1$
+			}
+		}
+
+		return zestStyle;
+	}
+
+	@Override
+	public boolean hasStyle(NodeStyle nodeStyle) {
+		Style nodeStyleParsed = styleAttribute();
+		if (nodeStyleParsed != null) {
+			for (StyleItem styleItem : nodeStyleParsed.getStyleItems()) {
+				if (styleItem.getName().equals(nodeStyle.toString())) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private boolean isNoneShape(Shape dotShape) {
+		if (dotShape != null) {
+			EObject shape = dotShape.getShape();
+			if (shape instanceof PolygonBasedShape) {
+				return ((PolygonBasedShape) shape)
+						.getShape() == PolygonBasedNodeShape.NONE;
+			}
+		}
+
+		return false;
+	}
+
+	protected void addNodeStyle(StringBuilder zestStyle, NodeStyle style,
+			boolean penwidthUnset) {
+		// in case of polygon-based nodes (default) shapes use 'stroke'
+		switch (style) {
+		case BOLD:
+			if (penwidthUnset)
+				zestStyle.append("-fx-stroke-width:2;"); //$NON-NLS-1$
+			break;
+		case DASHED:
+			zestStyle.append("-fx-stroke-dash-array: 7 7;"); //$NON-NLS-1$
+			break;
+		case DIAGONALS:
+			// TODO: add support for 'diagonals' styled nodes
+			break;
+		case DOTTED:
+			zestStyle.append("-fx-stroke-dash-array: 1 6;"); //$NON-NLS-1$
+			break;
+		case RADIAL:
+			// TODO: add support for 'radial' styled nodes
+			break;
+		case ROUNDED:
+			// TODO: add support for 'rounded' styled nodes
+			break;
+		case SOLID:
+			zestStyle.append("-fx-stroke-width: 1;"); //$NON-NLS-1$
+			break;
+		case STRIPED:
+			// TODO: add support for 'striped' styled nodes
+			break;
+		case WEDGED:
+			// TODO: add support for 'wedged' styled nodes
+			break;
+		}
+	}
+
+	protected String fillFxCssString() {
+		return "-fx-fill: "; //$NON-NLS-1$
+	}
+
+	protected String strokeWidthFxCssString() {
+		return "-fx-stroke-width:"; //$NON-NLS-1$
+	}
+
+	protected String strokeColorFxCssString() {
+		return "-fx-stroke: "; //$NON-NLS-1$
+	}
+
+	protected Shape shapeAttribute() {
+		return DotAttributes.getShapeParsed(dot);
+	}
+
+	protected String colorschemeAttribute() {
+		return DotAttributes.getColorscheme(dot);
+	}
+
+	protected Color colorAttribute() {
+		return DotAttributes.getColorParsed(dot);
+	}
+
+	protected Double penwidthAttribute() {
+		return DotAttributes.getPenwidthParsed(dot);
+	}
+
+	protected ColorList fillcolorAttribute() {
+		return DotAttributes.getFillcolorParsed(dot);
+	}
+
+	protected Style styleAttribute() {
+		return DotAttributes.getStyleParsed(dot);
+	}
+}

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotNodeStyleUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotNodeStyleUtil.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - initial API and implementation
+ *     
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.ui.conversion;
+
+import org.eclipse.gef.dot.internal.language.style.NodeStyle;
+
+public interface DotNodeStyleUtil {
+
+	/**
+	 * Computes Zest node shape style
+	 * 
+	 * @return StringBuilder containing node shape style
+	 */
+	public StringBuilder computeZestStyle();
+
+	/**
+	 * Checks if node has given style
+	 * 
+	 * @param nodeStyle
+	 * @return true, if node has nodeStyle
+	 */
+	public boolean hasStyle(NodeStyle nodeStyle);
+}

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotRecordBasedNodeStyleUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotRecordBasedNodeStyleUtil.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - original implementation, refactoring and initial API
+ *     Tamas Miklossy     (itemis AG) - original implementation
+ *     
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.ui.conversion;
+
+import org.eclipse.gef.dot.internal.DotAttributes;
+import org.eclipse.gef.dot.internal.language.color.Color;
+import org.eclipse.gef.dot.internal.language.shape.RecordBasedNodeShape;
+import org.eclipse.gef.dot.internal.language.shape.RecordBasedShape;
+import org.eclipse.gef.dot.internal.language.style.NodeStyle;
+import org.eclipse.gef.dot.internal.language.style.Style;
+import org.eclipse.gef.dot.internal.language.style.StyleItem;
+import org.eclipse.gef.graph.Node;
+
+public class DotRecordBasedNodeStyleUtil extends DotDefaultNodeStyleUtil {
+
+	boolean hasBorderStyle = false;
+
+	public DotRecordBasedNodeStyleUtil(DotColorUtil colorUtil, Node dot) {
+		super(colorUtil, dot);
+	}
+
+	@Override
+	public StringBuilder computeZestStyle() {
+		StringBuilder zestShapeStyle = super.computeZestStyle();
+
+		RecordBasedNodeShape recordBasedShape = ((RecordBasedShape) DotAttributes
+				.getShapeParsed(dot).getShape()).getShape();
+
+		// Mrecord shape has rounded edges (for border and fill)
+		if (RecordBasedNodeShape.MRECORD.equals(recordBasedShape))
+			zestShapeStyle.append(
+					"-fx-background-radius:10px;-fx-border-radius:10px;"); //$NON-NLS-1$
+
+		// If a border is set, we don't change this, but per default, there
+		// is a solid border in graphviz
+		if (!hasBorderStyle) // $NON-NLS-1$
+			zestShapeStyle.append("-fx-border-style:solid;"); //$NON-NLS-1$
+
+		return zestShapeStyle;
+	}
+
+	public StringBuilder computeLineStyle() {
+		StringBuilder zestStyle = new StringBuilder();
+		// color
+		Color dotColor = DotAttributes.getColorParsed(dot);
+		String dotColorScheme = DotAttributes.getColorscheme(dot);
+		String javaFxColor = colorUtil.computeZestColor(dotColorScheme,
+				dotColor);
+		if (javaFxColor != null) {
+			zestStyle.append("-fx-stroke:" + javaFxColor + ";"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		// penwidth
+		Double penwidth = DotAttributes.getPenwidthParsed(dot);
+		if (penwidth != null) {
+			zestStyle.append("-fx-stroke-width:"); //$NON-NLS-1$
+			zestStyle.append(penwidth);
+			zestStyle.append(";"); //$NON-NLS-1$
+		}
+
+		Style style = DotAttributes.getStyleParsed(dot);
+		if (style != null) {
+			for (StyleItem styleItem : style.getStyleItems()) {
+				NodeStyle nodeStyle = NodeStyle.get(styleItem.getName());
+				if (nodeStyle != null) {
+					super.addNodeStyle(zestStyle, nodeStyle, penwidth == null);
+				}
+			}
+		}
+
+		return zestStyle;
+	}
+
+	@Override
+	protected void addNodeStyle(StringBuilder zestStyle, NodeStyle style,
+			boolean penwidthUnset) {
+		// the node style needs use different JavaFX css attributes
+		// in case of record based nodes shapes use 'border'
+		switch (style) {
+		case BOLD:
+			if (penwidthUnset)
+				zestStyle.append("-fx-border-width:2;"); //$NON-NLS-1$
+			break;
+		case DASHED:
+			zestStyle.append("-fx-border-style:dashed;"); //$NON-NLS-1$
+			hasBorderStyle = true;
+			break;
+		case DIAGONALS:
+			// TODO: add support for 'diagonals' styled nodes
+			break;
+		case DOTTED:
+			zestStyle.append("-fx-border-style:dotted;"); //$NON-NLS-1$
+			hasBorderStyle = true;
+			break;
+		case RADIAL:
+			// TODO: add support for 'radial' styled nodes
+			break;
+		case ROUNDED:
+			// TODO: add support for 'rounded' styled nodes
+			break;
+		case SOLID:
+			zestStyle.append("-fx-border-style:solid;"); //$NON-NLS-1$
+			hasBorderStyle = true;
+			break;
+		case STRIPED:
+			// TODO: add support for 'striped' styled nodes
+			break;
+		case WEDGED:
+			// TODO: add support for 'wedged' styled nodes
+			break;
+		}
+	}
+
+	@Override
+	protected String strokeWidthFxCssString() {
+		return "-fx-border-width:"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected String strokeColorFxCssString() {
+		return "-fx-border-color:"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected String fillFxCssString() {
+		return "-fx-background-color:"; //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
Ignore Travis / Jenkins: Tests run locally (with the exception of two position tests, which I think will flicker anyway).

Please review or reply for rework:

- Should we integrate the NodeUtil class differently in the long term, so that it can be exchanged in another implementation?
- are the Contributors comments ok for you as they are? I was not sure how we wanted to do that. I did not want to just write my name and initial API & implementation, because that's not true - but thought it was too cumbersome to take over all the changes from Dot2ZestAttributesConverter ...

If you agree, we can merge it that way! (Sorry for the poor English,  accidentially had it all typed in German so used auto translation)