### PR TITLE
[461506] DotImport: Include all currently implemented cluster attributes

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotImportTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotImportTest.xtend
@@ -1707,6 +1707,136 @@ class DotImportTest {
 		DotTestGraphs.NODE_XLP_LOCAL.assertImportedTo(expected)
 	}
 
+	@Test def cluster_bgcolor() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.bgcolor=p2], "red")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_BGCOLOR.assertImportedTo(expected)
+	}
+
+	@Test def cluster_color() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.color=p2], "red")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_COLOR.assertImportedTo(expected)
+	}
+
+	@Test def cluster_colorscheme() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.colorscheme=p2], "svg")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_COLORSCHEME.assertImportedTo(expected)
+	}
+
+	@Test def cluster_fillcolor() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.fillcolor=p2], "red")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_FILLCOLOR.assertImportedTo(expected)
+	}
+
+	@Test def cluster_fontcolor() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.fontcolor=p2], "red")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_FONTCOLOR.assertImportedTo(expected)
+	}
+
+	@Test def cluster_fontname() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.fontname=p2], "Helvetica")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_FONTNAME.assertImportedTo(expected)
+	}
+
+	@Test def cluster_fontsize() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.fontsize=p2], "2")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_FONTSIZE.assertImportedTo(expected)
+	}
+
+	@Test def cluster_id() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.id=p2], "FOO")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_ID.assertImportedTo(expected)
+	}
+
+	@Test def cluster_label() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.label=p2], "foo")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_LABEL.assertImportedTo(expected)
+	}
+
+	@Test def cluster_lp() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.lp=p2], "-4.5,-6.7")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_LP.assertImportedTo(expected)
+	}
+
 	@Test def cluster_penwidth() {
 		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
 		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.penwidth=p2], "2")
@@ -1718,6 +1848,32 @@ class DotImportTest {
 		var expected = graph.nodes(n1).build
 		
 		DotTestGraphs.CLUSTER_PENWIDTH.assertImportedTo(expected)
+	}
+
+	@Test def cluster_style() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.style=p2], "dashed")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_STYLE.assertImportedTo(expected)
+	}
+
+	@Test def cluster_tooltip() {
+		var graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH)
+		var nestedGraph = new Graph.Builder().attr([p1,p2|p1._setName(p2)], "clusterName").attr([p1,p2|p1.tooltip=p2], "foo")
+		
+		val n1 = new Node.Builder().buildNode
+		val n11 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		
+		n1.nestedGraph = nestedGraph.nodes(n11).build
+		var expected = graph.nodes(n1).build
+		
+		DotTestGraphs.CLUSTER_TOOLTIP.assertImportedTo(expected)
 	}
 
 	@Test def clusters() {

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotTestGraphs.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotTestGraphs.xtend
@@ -379,7 +379,7 @@ class DotTestGraphs {
 			1;2;3;4;
 			1->2; 2->3; 2->4;
 		}
-	'''	
+	'''
 
 	public static val GRAPH_LAYOUT_OSAGE = '''
 		digraph {
@@ -395,7 +395,97 @@ class DotTestGraphs {
 			1;2;3;4;
 			1->2; 2->3; 2->4;
 		}
-	''' 
+	'''
+
+	public static val CLUSTER_BGCOLOR = '''
+		graph {
+			subgraph clusterName {
+				graph [bgcolor=red];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_COLOR = '''
+		graph {
+			subgraph clusterName {
+				graph [color=red];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_COLORSCHEME = '''
+		graph {
+			subgraph clusterName {
+				graph [colorscheme=svg];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_FILLCOLOR = '''
+		graph {
+			subgraph clusterName {
+				graph [fillcolor=red];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_FONTCOLOR = '''
+		graph {
+			subgraph clusterName {
+				graph [fontcolor=red];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_FONTNAME = '''
+		graph {
+			subgraph clusterName {
+				graph [fontname=Helvetica];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_FONTSIZE = '''
+		graph {
+			subgraph clusterName {
+				graph [fontsize=2];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_ID = '''
+		graph {
+			subgraph clusterName {
+				graph [id=FOO];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_LABEL = '''
+		graph {
+			subgraph clusterName {
+				graph [label=foo];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_LP = '''
+		graph {
+			subgraph clusterName {
+				graph [lp="-4.5,-6.7"];
+				1
+			}
+		}
+	'''
 
 	public static val CLUSTER_PENWIDTH = '''
 		graph {
@@ -404,7 +494,25 @@ class DotTestGraphs {
 				1
 			}
 		}
-	''' 
+	'''
+
+	public static val CLUSTER_STYLE = '''
+		graph {
+			subgraph clusterName {
+				graph [style=dashed];
+				1
+			}
+		}
+	'''
+
+	public static val CLUSTER_TOOLTIP = '''
+		graph {
+			subgraph clusterName {
+				graph [tooltip=foo];
+				1
+			}
+		}
+	'''
 
 	public static val GRAPH_RANKDIR_LR = '''
 		graph {

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotImport.xtend
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotImport.xtend
@@ -312,12 +312,18 @@ class DotImport {
 		// subgraph/cluster attributes
 		setter.apply(BB__GC, [g, value|g.setBbRaw(value)])
 		setter.apply(BGCOLOR__GC, [g, value|g.setBgcolorRaw(value)])
+		setter.apply(COLOR__CNE, [g, value|g.setColorRaw(value)])
+		setter.apply(COLORSCHEME__GCNE, [g, value|g.setColorschemeRaw(value)])
+		setter.apply(FILLCOLOR__CNE, [g, value|g.setFillcolorRaw(value)])
 		setter.apply(FONTCOLOR__GCNE, [g, value|g.setFontcolorRaw(value)])
-		setter.apply(FONTNAME__GCNE, [g, value|g.setFontnameRaw(value)])		
+		setter.apply(FONTNAME__GCNE, [g, value|g.setFontnameRaw(value)])
 		setter.apply(FONTSIZE__GCNE, [g, value|g.setFontsizeRaw(value)])
+		setter.apply(ID__GCNE, [g, value|g.setIdRaw(value)])
 		setter.apply(LABEL__GCNE, [g, value|g.setLabelRaw(value)])
+		setter.apply(LP__GCE, [g, value|g.setLpRaw(value)])
 		setter.apply(RANK__S, [g, value|g.setRankRaw(value)])
 		setter.apply(PENWIDTH__CNE, [g, value|g.setPenwidthRaw(value)])
+		setter.apply(STYLE__GCNE, [g, value|g.setStyleRaw(value)])
 		setter.apply(TOOLTIP__CNE, [g, value|g.setTooltipRaw(value)])
 	}
 


### PR DESCRIPTION
- Implement corresponding DotImportTests (and DotTestGraphs)

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=461506