### PR TITLE
[541052] Implement Cluster Style support

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTest.xtend
@@ -69,6 +69,536 @@ class Dot2ZestGraphCopierTest {
 		dot2ZestGraphCopier.attributeCopier.options.emulateLayout = false
 	}
 
+	@Test def cluster_bgcolor001() {
+		'''
+			digraph {
+				subgraph clusterName {
+					bgcolor=yellow;
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-fill: #ffff00;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_bgcolor002() {
+		'''
+			digraph {
+				subgraph clusterName {
+					bgcolor=yellow fillcolor=green;
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-fill: #ffff00;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_color() {
+		'''
+			digraph {
+				subgraph clusterName {
+					color=yellow;
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke: #ffff00;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_colorscheme() {
+		//The colorscheme itself is not a Zest property, but we can check, it is not ignored. Aqua is not a default x11 colour.
+		'''
+			digraph {
+				subgraph clusterName {
+					color=aqua colorscheme=svg;
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke: #00ffff;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_fillcolor001() {
+		'''
+			digraph {
+				subgraph clusterName {
+					fillcolor=green;
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-fill: #00ff00;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_fillcolor002() {
+		'''
+			digraph {
+				subgraph clusterName {
+					graph [fillcolor=green, style=filled];
+					2
+				}
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-fill: #00ff00;
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_fontcolor() {
+		'''
+			digraph {
+				subgraph clusterName {
+					fontcolor=green label=foo;
+					1
+				}
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-external-label : foo
+					element-external-label-css-style : -fx-fill: #00ff00;
+					element-label : 
+					node-rect-css-style : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_fontname() {
+		mockAvailableFonts("Times New Roman")
+		'''
+			digraph {
+				subgraph clusterName {
+					label="foo"
+					fontname="Times-Bold"
+					1
+				}
+				2
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-external-label : foo
+					element-external-label-css-style : -fx-font-family: "Times New Roman";-fx-font-weight: 700;-fx-font-style: normal;
+					element-label : 
+					node-rect-css-style : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node3 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_fontsize() {
+		'''
+			digraph {
+				subgraph clusterName {
+					label="foo"
+					fontsize="4"
+					1
+				}
+				2
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-external-label : foo
+					element-external-label-css-style : -fx-font-size: 4.0;
+					element-label : 
+					node-rect-css-style : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node3 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_id() {
+		// This test shows current behaviour, it needs adaptation once the attribute is supported.
+		'''
+			digraph {
+				subgraph clusterName {
+					id="EASTEREGG"
+					1
+				}
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_label() {
+		'''
+			digraph {
+				subgraph clusterName {
+					label=green;
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-external-label : green
+					element-label : 
+					node-rect-css-style : 
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+
+	@Test def cluster_lp() {
+		// This test shows current behaviour, it needs adaptation once the attribute is supported.
+		'''
+			digraph {
+				subgraph clusterName {
+					lp="80,80";
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : 
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_penwidth001() {
+		'''
+			digraph {
+				subgraph clusterName {
+					penwidth=2
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke-width:2.0;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_penwidth002() {
+		'''
+			digraph {
+				subgraph clusterName {
+					style=bold
+					penwidth=2
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke-width:2.0;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_penwidth003() {
+		'''
+			digraph {
+				subgraph clusterName {
+					style=solid
+					penwidth=2
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke-width:2.0;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_style001() {
+		'''
+			digraph {
+				subgraph clusterName {
+					style=dashed
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke-dash-array: 7 7;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_style002() {
+		'''
+			digraph {
+				subgraph clusterName {
+					style=dotted
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke-dash-array: 1 6;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_style003() {
+		'''
+			digraph {
+				subgraph clusterName {
+					style=bold
+					1
+				}
+			}
+		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : -fx-stroke-width:2;
+					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_style004() {
+		// This test shows current behaviour, it needs adaptation once the attribute is supported.
+		'''
+			digraph {
+				subgraph clusterName {
+					graph [style="rounded"]
+					2
+				}
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 2
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
+	@Test def cluster_tooltip() {
+		// This test shows current behaviour, it needs adaptation once the attribute is supported.
+		'''
+			digraph {
+				subgraph clusterName {
+					tooltip="foo"
+					1
+				}
+			}
+		'''.assertZestConversion('''
+			Graph {
+				Node1 {
+					element-label : 
+					node-rect-css-style : 
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+				Node2 {
+					element-label : 1
+					node-shape : GeometryNode
+					node-size : Dimension(54.0, 36.0)
+				}
+			}
+		''')
+	}
+
 	@Test def edge_arrowhead001() {
 		'''
 			digraph {
@@ -1388,6 +1918,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -1412,6 +1943,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -1436,6 +1968,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -1459,6 +1992,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -1471,58 +2005,8 @@ class Dot2ZestGraphCopierTest {
 		''')
 	}
 
-	@Test def cluster_color() {
-		// This test shows current behaviour, it needs adaptation once the attribute is FULLY supported.
-		'''
-			digraph {
-				subgraph clusterName {
-					graph [color=yellow];
-					1
-				}
-			}
-		'''.assertZestConversion(new NodeShapeWithStylePrettyPrinter, '''
-			Graph {
-				Node1 {
-					element-label : 
-					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0), style: 
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
-					element-label : 1
-					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0), style: 
-					node-size : Dimension(54.0, 36.0)
-				}
-			}
-		''')
-	}
-
 	@Test def void graph_colorscheme() {
 		// TODO: implement once the issue with attribute support is resolved (bug 540508)
-	}
-
-	@Test def graph_fillcolor() {
-		// This test shows current behaviour, it needs adaptation once the attribute is supported.
-		'''
-			digraph {
-				subgraph clusterName {
-					graph [fillcolor=green, style=filled];
-					2
-				}
-			}
-		'''.assertZestConversion('''
-			Graph {
-				Node1 {
-					element-label : 
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
-					element-label : 2
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-			}
-		''')
 	}
 
 	@Test def graph_fontcolor() {
@@ -1561,41 +2045,6 @@ class Dot2ZestGraphCopierTest {
 			}
 		''')
 	}
-
-	@Test def cluster_fontname() {
-		mockAvailableFonts("Times New Roman")
-		'''
-			digraph {
-				subgraph clusterName {
-					label="foo"
-					fontname="Times-Bold"
-					1
-				}
-				2
-			}
-		'''.assertZestConversion('''
-			Graph {
-				Node1 {
-					element-external-label : foo
-					element-external-label-css-style : -fx-font-family: "Times New Roman";-fx-font-weight: 700;-fx-font-style: normal;
-					element-label : 
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
-					element-label : 1
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node3 {
-					element-label : 2
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-			}
-		''')
-	}
-	
 
 	@Test def graph_fontsize() {
 		// This test shows current behaviour, it needs adaptation once the attribute is supported.
@@ -2408,56 +2857,6 @@ class Dot2ZestGraphCopierTest {
 					edge-curve : GeometryNode
 					edge-curve-css-style : -fx-stroke-line-cap: butt;
 					edge-target-decoration : Polygon[points=[0.0, 0.0, 10.0, -3.3333333333333335, 10.0, 3.3333333333333335], fill=0x000000ff]
-				}
-			}
-		''')
-	}
-
-	@Test def graph_style() {
-		// This test shows current behaviour, it needs adaptation once the attribute is supported.
-		'''
-			digraph {
-				subgraph clusterName {
-					graph [style="rounded"]
-					2
-				}
-			}
-		'''.assertZestConversion('''
-			Graph {
-				Node1 {
-					element-label : 
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
-					element-label : 2
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-			}
-		''')
-	}
-
-	@Test def cluster_tooltip() {
-		// This test shows current behaviour, it needs adaptation once the attribute is supported.
-		'''
-			digraph {
-				subgraph clusterName {
-					graph [tooltip="foo"]
-					1
-				}
-			}
-		'''.assertZestConversion('''
-			Graph {
-				Node1 {
-					element-label : 
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
-					element-label : 1
-					node-shape : GeometryNode
-					node-size : Dimension(54.0, 36.0)
 				}
 			}
 		''')
@@ -4260,6 +4659,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -4345,6 +4745,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -4426,6 +4827,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -4474,6 +4876,7 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
@@ -4522,11 +4925,13 @@ class Dot2ZestGraphCopierTest {
 			Graph {
 				Node1 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}
 				Node2 {
 					element-label : 
+					node-rect-css-style : 
 					node-shape : GeometryNode
 					node-size : Dimension(54.0, 36.0)
 				}

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestNodeAttributesConversionTest.xtend
@@ -673,7 +673,7 @@ class Dot2ZestNodeAttributesConversionTest {
 				1[style=solid]
 			}
 		'''.assertNodeStyle('''
-			-fx-stroke-width: 1;
+			-fx-stroke-width:1;
 		''')
 	}
 

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/Dot2ZestAttributesConverter.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/Dot2ZestAttributesConverter.java
@@ -110,7 +110,7 @@ public class Dot2ZestAttributesConverter implements IAttributeCopier {
 		public boolean invertYAxis = false;
 	}
 
-	private DotColorUtil colorUtil = new DotColorUtil();
+	DotColorUtil colorUtil = new DotColorUtil();
 	public final DotFontUtil fontUtil = new DotFontUtil();
 
 	@Override

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/Dot2ZestGraphCopier.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/Dot2ZestGraphCopier.java
@@ -119,6 +119,11 @@ public class Dot2ZestGraphCopier extends GraphCopier {
 
 		Dot2ZestAttributesConverter attributesCopier = getAttributeCopier();
 
+		// cluster node style
+		ZestProperties.setShapeCssStyle(zestNode,
+				new DotClusterStyleUtil(attributesCopier.colorUtil, dotNode)
+						.computeZestStyle().toString());
+
 		// label fontcolor, fontsize, fontname
 		String zestNodeLabelCssStyle = attributesCopier
 				.computeZestGraphLabelCssStyle(dotNode.getNestedGraph());

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotClusterStyleUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotClusterStyleUtil.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Zoey Gerrit Prigge (itemis AG) - initial API and implementation (bug #541052)
+ *
+ *******************************************************************************/
+package org.eclipse.gef.dot.internal.ui.conversion;
+
+import org.eclipse.gef.dot.internal.DotAttributes;
+import org.eclipse.gef.dot.internal.language.color.Color;
+import org.eclipse.gef.dot.internal.language.colorlist.ColorList;
+import org.eclipse.gef.dot.internal.language.shape.Shape;
+import org.eclipse.gef.dot.internal.language.style.Style;
+import org.eclipse.gef.graph.Node;
+
+public class DotClusterStyleUtil extends DotDefaultNodeStyleUtil {
+
+	public DotClusterStyleUtil(DotColorUtil colorUtil, Node dot) {
+		super(colorUtil, dot);
+	}
+
+	@Override
+	protected Shape shapeAttribute() {
+		// Clusters have no shape Attribute
+		return null;
+	}
+
+	@Override
+	protected String colorschemeAttribute() {
+		return DotAttributes.getColorscheme(dot.getNestedGraph());
+	}
+
+	@Override
+	protected Color colorAttribute() {
+		return DotAttributes.getColorParsed(dot.getNestedGraph());
+	}
+
+	@Override
+	protected Double penwidthAttribute() {
+		return DotAttributes.getPenwidthParsed(dot.getNestedGraph());
+	}
+
+	@Override
+	protected ColorList fillcolorAttribute() {
+		// in graphviz practice, bgcolor overrides fillcolor, if present
+		ColorList bgColor = DotAttributes
+				.getBgcolorParsed(dot.getNestedGraph());
+		ColorList fillColor = DotAttributes
+				.getFillcolorParsed(dot.getNestedGraph());
+		return bgColor != null ? bgColor : fillColor;
+	}
+
+	@Override
+	protected boolean fillCondition() {
+		// if fillcolor or bgcolor is set, style needs not be set to filled
+		return fillcolorAttribute() != null;
+	}
+
+	@Override
+	protected Style styleAttribute() {
+		return DotAttributes.getStyleParsed(dot.getNestedGraph());
+	}
+}

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotDefaultNodeStyleUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotDefaultNodeStyleUtil.java
@@ -77,7 +77,7 @@ public class DotDefaultNodeStyleUtil implements DotNodeStyleUtil {
 		}
 
 		// fillcolor: evaluate only if the node style is set to 'filled'.
-		if (hasStyle(NodeStyle.FILLED)) {
+		if (fillCondition()) {
 			Color dotFillColor = null;
 			ColorList fillColor = fillcolorAttribute();
 			if (fillColor != null && !fillColor.getColorValues().isEmpty()) {
@@ -149,7 +149,8 @@ public class DotDefaultNodeStyleUtil implements DotNodeStyleUtil {
 			// TODO: add support for 'rounded' styled nodes
 			break;
 		case SOLID:
-			zestStyle.append("-fx-stroke-width: 1;"); //$NON-NLS-1$
+			if (penwidthUnset)
+				zestStyle.append("-fx-stroke-width:1;"); //$NON-NLS-1$
 			break;
 		case STRIPED:
 			// TODO: add support for 'striped' styled nodes
@@ -190,6 +191,10 @@ public class DotDefaultNodeStyleUtil implements DotNodeStyleUtil {
 
 	protected ColorList fillcolorAttribute() {
 		return DotAttributes.getFillcolorParsed(dot);
+	}
+
+	protected boolean fillCondition() {
+		return hasStyle(NodeStyle.FILLED);
 	}
 
 	protected Style styleAttribute() {

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/styles.css
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/styles.css
@@ -11,7 +11,7 @@
  */
 
 .node .shape {
-	-fx-fill: white;
+	-fx-fill: transparent;
 	-fx-stroke: black;
 }
 


### PR DESCRIPTION
-Implement a DotClusterStyleUtil
-Implement small changes in DotDefaultNodeStyleUtil
-Implement necessary changes in Dot2ZestGraphCopier and
Dot2ZestAttributesConverter
-change nodes to have transparent standard fill in styles.css to allow
for cluster background
-Implement/Rename corresponding Dot2ZestGraphCopierTests

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=541052