### PR TITLE
[540508] Fix Colorscheme Bgcolor NPE

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotImportTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotImportTest.xtend
@@ -1158,6 +1158,16 @@ class DotImportTest {
 		DotTestGraphs.GRAPH_BGCOLOR_LOCAL.assertImportedTo(expected)
 	}
 
+	@Test def graph_colorscheme() {
+		// test local attribute
+		val graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH).
+			attr([p1,p2|p1.colorscheme=p2], "svg")
+		val n1 = new Node.Builder().attr([p1,p2|p1._setName(p2)], "1").buildNode
+		val expected = graph.nodes(n1).build
+		
+		DotTestGraphs.GRAPH_COLORSCHEME_SVG.assertImportedTo(expected)
+	}
+
 	@Test def graph_fontcolor() {
 		// test global attribute
 		val graph = new Graph.Builder().attr([p1,p2|p1._setType(p2)], GraphType.GRAPH).

--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotTestGraphs.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotTestGraphs.xtend
@@ -568,7 +568,13 @@ class DotTestGraphs {
 			}
 		}
 	'''
-
+	
+	public static val GRAPH_COLORSCHEME_SVG = '''
+		graph {
+			colorscheme=svg
+			1
+		}
+	'''
 /*
  ************************************************************************************************************
  * Test dot graphs with global/local/override dot attributes

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotGraphView.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/DotGraphView.java
@@ -12,6 +12,7 @@
  *     Alexander Nyßen (itemis AG) - Refactorings and cleanups
  *     Tamas Miklossy (itemis AG) - Refactoring of preferences (bug #446639)
  *                                - Render embedded dot graphs in native mode (bug #493694)
+ *     Zoey Prigge (itemis AG)    - Avoid NPE when setting ungrammatical bgcolor (bug #540508)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal.ui;
@@ -309,17 +310,20 @@ public class DotGraphView extends ZestFxUiView implements IShowInTarget {
 
 		// apply graph background color
 		// TODO: add Zest property for background color
-		// TODO: convert bgcolorList (Dot) to backgroubd color (Zest) within
+		// TODO: convert bgcolorList (Dot) to background color (Zest) within
 		// Dot2ZestAttributesConverter
 		DotColorUtil colorUtil = new DotColorUtil();
 		ColorList bgcolorList = DotAttributes.getBgcolorParsed(graph);
+		Paint backgroundColor = null;
 		if (bgcolorList != null && bgcolorList.getColorValues() != null
 				&& bgcolorList.getColorValues().size() > 0) {
 			// FIXME: apply all colors. Currently, only the first one is
 			// applied.
-			Paint backgroundColor = colorUtil.computeGraphBackgroundColor(
+			backgroundColor = colorUtil.computeGraphBackgroundColor(
 					DotAttributes.getColorscheme(graph),
 					bgcolorList.getColorValues().get(0).getColor());
+		}
+		if (backgroundColor != null) {
 			addGraphBackground(backgroundColor);
 		} else {
 			removeGraphBackground();

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotColorUtil.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/conversion/DotColorUtil.java
@@ -10,6 +10,7 @@
  *     Matthias Wienand   (itemis AG) - Initial API and contribution
  *     Tamas Miklossy     (itemis AG) - Initial API and contribution
  *     Zoey Gerrit Prigge (itemis AG) - compute HTML color (bug #321775)
+ *                                    - avoid ungrammatical color causing NPE (bug #540508)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal.ui.conversion;
@@ -83,10 +84,13 @@ public class DotColorUtil {
 					Double.parseDouble(hsvColor.getS()),
 					Double.parseDouble(hsvColor.getV()));
 		} else {
-			return javafx.scene.paint.Color
-					.web(computeZestColor(colorScheme, dotColor));
+			String javaFxStringColor = computeZestColor(colorScheme, dotColor);
+			// avoid ungrammatical color attribute causing NPE (bug #540508)
+			if (javaFxStringColor != null) {
+				return javafx.scene.paint.Color.web(javaFxStringColor);
+			}
 		}
-
+		return null;
 	}
 
 	/**

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotImport.xtend
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotImport.xtend
@@ -140,6 +140,7 @@ class DotImport {
 		setter.apply(BB__GC, [g, value|g.setBbRaw(value)])
 		setter.apply(BGCOLOR__GC, [g, value|g.setBgcolorRaw(value)])
 		setter.apply(CLUSTERRANK__G, [g, value|g.setClusterrankRaw(value)])
+		setter.apply(COLORSCHEME__GCNE, [g, value|g.setColorschemeRaw(value)])
 		setter.apply(FONTCOLOR__GCNE, [g, value|g.setFontcolorRaw(value)])
 		setter.apply(FONTNAME__GCNE, [g, value|g.setFontnameRaw(value)])
 		setter.apply(FONTSIZE__GCNE, [g, value|g.setFontsizeRaw(value)])


### PR DESCRIPTION
-include colorscheme graph attribute in DotImport
-implement corresponding DotImportTest and DotTestGraph
-include null checks in DotColorUtil and DotGraphView to exclude other
cases of ungrammatical color names.

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=540508