### PR TITLE
[547809] Clusterrank awareness in DotAttributes::isCluster

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/Dot2ZestGraphCopierTest.xtend
@@ -1905,7 +1905,6 @@ class Dot2ZestGraphCopierTest {
 	}
 
 	@Test def graph_clusterrank001() {
-		// This test shows current behaviour, it needs adaptation once the attribute is supported.
 		// Note: clusterrank defaults to local; none and global turn the cluster processing off.
 		'''
 			digraph {
@@ -1917,12 +1916,6 @@ class Dot2ZestGraphCopierTest {
 		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
 			Graph {
 				Node1 {
-					element-label : 
-					node-rect-css-style : 
-					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
 					element-label : 1
 					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
 					node-size : Dimension(54.0, 36.0)
@@ -1932,6 +1925,7 @@ class Dot2ZestGraphCopierTest {
 	}
 
 	@Test def graph_clusterrank002() {
+		// Note: clusterrank defaults to local; none and global turn the cluster processing off.
 		'''
 			digraph {
 				graph [clusterrank=none];
@@ -1942,12 +1936,6 @@ class Dot2ZestGraphCopierTest {
 		'''.assertZestConversion(new NodeShapePrettyPrinter, '''
 			Graph {
 				Node1 {
-					element-label : 
-					node-rect-css-style : 
-					node-shape : Rectangle: (0.0, 0.0, 0.0, 0.0)
-					node-size : Dimension(54.0, 36.0)
-				}
-				Node2 {
 					element-label : 1
 					node-shape : Ellipse (0.0, 0.0, 0.0, 0.0)
 					node-size : Dimension(54.0, 36.0)
@@ -1957,6 +1945,7 @@ class Dot2ZestGraphCopierTest {
 	}
 
 	@Test def graph_clusterrank003() {
+		// Note: clusterrank defaults to local; none and global turn the cluster processing off.
 		'''
 			digraph {
 				graph [clusterrank=local];
@@ -1982,6 +1971,7 @@ class Dot2ZestGraphCopierTest {
 	}
 
 	@Test def graph_clusterrank004() {
+		// Note: clusterrank defaults to local; none and global turn the cluster processing off.
 		'''
 			digraph {
 				subgraph clusterName {

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotAttributes.xtend
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/DotAttributes.xtend
@@ -10,6 +10,7 @@
  *     Alexander Nyßen    (itemis AG) - initial API and implementation
  *     Tamas Miklossy     (itemis AG) - Add support for all dot attributes (bug #461506)
  *     Zoey Gerrit Prigge (itemis AG) - Add support for all dot attributes (bug #461506)
+ *                                    - Add clusterrank check in isCluster (bug #547809)
  *
  *******************************************************************************/
 package org.eclipse.gef.dot.internal
@@ -144,10 +145,19 @@ class DotAttributes {
 		}
 }
 	static def boolean isCluster(Node node) {
-		if(node.nestedGraph === null) {
+		var Graph rootGraph = null;
+		for (var nestingNode = node; 
+			nestingNode !== null; 
+			nestingNode = rootGraph?.nestingNode) {
+			rootGraph = nestingNode.graph;
+		}
+		
+		if (node.nestedGraph === null || rootGraph !== null &&
+			#[ClusterMode.NONE, ClusterMode.GLOBAL].contains(rootGraph.clusterrankParsed)) {
 			return false
 		}
-		val name =  node.nestedGraph._getName
+
+		val name = node.nestedGraph._getName
 		return name !== null && name.startsWith("cluster")
 	}
 


### PR DESCRIPTION
-Make isCluster method aware of clusterrank set in root containing graph
-Implement corresponding DotAttributesTest
-adapt Dot2ZestGraphCopierTest(s)

Signed-off-by: Zoey Gerrit Prigge <zoey.prigge@uni-duesseldorf.de>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=547809