### PR TITLE
[NONE] Fix automatic travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 itemis AG and others.
+# Copyright (c) 2016, 2019 itemis AG and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
 #
 # Contributors:
 #     Alexander Nyßen (itemis AG) - initial API and implementation
+#     Zoey Prigge (itemis AG) - add manual trusty distribution
 ###############################################################################
 
 sudo: false
@@ -15,6 +16,8 @@ language: java
 
 jdk: 
  - oraclejdk8
+
+dist: trusty
 
 cache:
   directories:


### PR DESCRIPTION
As previously discussed:

mwienand 14 days ago
I would like to stick to Xenial if possible due to the standard support until 2021.

What is the reasoning w.r.t. using Trusty?

 @prggz
prggz 8 days ago Author Owner
The builds don't work anymore. They always ran on trusty (if you check the travis builds "system_info" here https://travis-ci.org/eclipse/gef/builds/570840063?utm_source=github_status&utm_medium=notification ). Since we were changed to Xenial as per https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment, they fail "Expected feature release number in range of 9 to 12, but got: 8". I googled, and it appears to have to do with us using the java8 JDK, which is not available anymore in xenial.

 @prggz
prggz 8 days ago Author Owner
This was more of a fix though to allow me to check, if travis runs through under "old" settings, rather than something I wanted to change in the main repo.

If we needed to do this, I think a separate commit would be more appropriate.

 @mwienand
mwienand 8 days ago
Okay, that is a very good reason :D

We should definitely try to upgrade to Java 11 (due to LTS), but until then, Trusty is fine.

 @prggz
prggz 7 days ago Author Owner
Okay. I will prepare a separate PR to add this to the main repo in that case.