### PR TITLE
[553575] Dot Editor: Html-Like Label BGColor Attribute CA support

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotHtmlLabelContentAssistTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotHtmlLabelContentAssistTest.xtend
@@ -487,9 +487,42 @@ class DotHtmlLabelContentAssistTest extends AbstractContentAssistTest {
 		'''
 			<TABLE BGCOLOR="«c»" ></TABLE>
 		'''.testContentAssistant(
-			combine(expectedX11ColorNames, #["#", "/"]), 
+			combine(expectedX11ColorNames, #["#", "/", ":"]), 
 			"red", '''
 				<TABLE BGCOLOR="red" ></TABLE>
+			'''
+		)
+	}
+	
+	@Test def attribute_values_of_tag_TABLE_BGCOLOR_Colon() {
+		'''
+			<TABLE BGCOLOR="red«c»" ></TABLE>
+		'''.testContentAssistant(
+			#["red", "red1", "red2", "red3", "red4", ":"], 
+			":", '''
+				<TABLE BGCOLOR="red:" ></TABLE>
+			'''
+		)
+	}
+	
+	@Test def attribute_values_of_tag_TABLE_BGCOLOR_with_Colon() {
+		'''
+			<TABLE BGCOLOR="«c»:" ></TABLE>
+		'''.testContentAssistant(
+			combine(expectedX11ColorNames, #["#", "/"]), 
+			"red", '''
+				<TABLE BGCOLOR="red:" ></TABLE>
+			'''
+		)
+	}
+	
+	@Test def attribute_values_of_tag_TABLE_BGCOLOR_after_Colon() {
+		'''
+			<TABLE BGCOLOR="blue:«c»" ></TABLE>
+		'''.testContentAssistant(
+			combine(expectedX11ColorNames, #["#", "/"]), 
+			"red", '''
+				<TABLE BGCOLOR="blue:red" ></TABLE>
 			'''
 		)
 	}
@@ -657,7 +690,7 @@ class DotHtmlLabelContentAssistTest extends AbstractContentAssistTest {
 		'''
 			<TD BGCOLOR="«c»" ></TD>
 		'''.testContentAssistant(
-			combine(expectedX11ColorNames, #["#", "/"]), 
+			combine(expectedX11ColorNames, #["#", "/", ":"]), 
 			"blue", '''
 				<TD BGCOLOR="blue" ></TD>
 			'''
@@ -862,7 +895,11 @@ class DotHtmlLabelContentAssistTest extends AbstractContentAssistTest {
 			 * replacement strings when determining the proposed text.
 			 */
 			override protected getProposedText(ICompletionProposal proposal) {
-				return proposal.displayString.split(":").head
+				val displayString = proposal.displayString
+				if(":".equals(displayString)) {
+					displayString
+				}
+				else displayString.split(":").head
 			}
 		}
 	}

--- a/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/htmllabel/DotHtmlLabelHelper.java
+++ b/org.eclipse.gef.dot/src/org/eclipse/gef/dot/internal/language/htmllabel/DotHtmlLabelHelper.java
@@ -235,7 +235,10 @@ public class DotHtmlLabelHelper {
 			HtmlTag tag = content.getTag();
 			String text = content.getText();
 
-			if (tag != null && ("TABLE".equals(tag.getName().toUpperCase()))) {
+			if (tag != null && tag.getName() == null) {
+				continue;
+			} else if (tag != null
+					&& ("TABLE".equals(tag.getName().toUpperCase()))) {
 				htmlTableSiblings.add(tag);
 			} else if (tag != null
 					&& ("IMG".equals(tag.getName().toUpperCase()))) {


### PR DESCRIPTION
-Implement support for CA with the gradient colon separated bgcolor
format in DotHtmlProposalProvider
-Change the prefix based use of DotProposalProviderDelegator to use of
current node if possible
-Implement corresponding DotHtmlContentAssistTests

Signed-off-by: zprigge <zprigge@itemis.com>
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=553575