### PR TITLE
#88 Cannot reduce the visibility of the overridden method

### DIFF
--- a/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotHighlightingTest.xtend
+++ b/org.eclipse.gef.dot.tests/src/org/eclipse/gef/dot/tests/DotHighlightingTest.xtend
@@ -9,6 +9,7 @@
  * Contributors:
  *    Tamas Miklossy (itemis AG) - initial API and implementation
  *    Zoey Prigge    (itemis AG) - strikethrough/deprecation (bug #552993)
+ *    Christoph Läubrich - compatibility with later xtend version (https://github.com/eclipse/gef/issues/88)
  * 
  *******************************************************************************/
 package org.eclipse.gef.dot.tests
@@ -191,12 +192,12 @@ class DotHighlightingTest extends AbstractHighlightingTest {
 	protected override openInEditor(IFile dslFile) {
 		val editor = dslFile.openEditor
 		
-		waitForEventProcessing
+		waitForEventProcessingWorkaround
 	
 		editor.internalSourceViewer.textWidget
 	}
 
-	private def waitForEventProcessing() {
+	protected def waitForEventProcessingWorkaround() {
 		while (Display.^default.readAndDispatch) { }
 	}
 }


### PR DESCRIPTION
Hope everything is fine as the contribution mentioned bugzilla in some places I'd tried to adopt this for github-issues.

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>
Bug: https://github.com/eclipse/gef/issues/88