### PR TITLE
Remove javax.inject bundle from GEF features

### DIFF
--- a/org.eclipse.gef.common-feature/feature.xml
+++ b/org.eclipse.gef.common-feature/feature.xml
@@ -34,7 +34,6 @@
    <requires>
       <import plugin="com.google.guava" version="12.0.0" match="greaterOrEqual"/>
       <import plugin="com.google.inject" version="5.0.0" match="compatible"/>
-      <import plugin="javax.inject" version="1.0.0" match="compatible"/>
       <import feature="org.eclipse.fx.runtime.min.feature" version="2.0.0" match="greaterOrEqual"/>
    </requires>
 

--- a/org.eclipse.gef.mvc.examples-feature/feature.xml
+++ b/org.eclipse.gef.mvc.examples-feature/feature.xml
@@ -42,7 +42,6 @@
       <import feature="org.eclipse.gef.mvc.fx.ui" version="5.0.0" match="compatible"/>
       <import plugin="com.google.guava" version="12.0.0" match="greaterOrEqual"/>
       <import plugin="com.google.inject" version="5.0.0" match="compatible"/>
-      <import plugin="javax.inject" version="1.0.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/org.eclipse.gef.mvc.examples.logo.web.repository/category.xml
+++ b/org.eclipse.gef.mvc.examples.logo.web.repository/category.xml
@@ -12,7 +12,6 @@
  -->
 <site>
    <bundle id="com.google.inject" version="0.0.0"/>
-   <bundle id="javax.inject" version="0.0.0"/>
    <bundle id="javax.xml" version="0.0.0"/>
    <bundle id="org.eclipse.osgi" version="0.0.0"/>
    <bundle id="org.eclipse.equinox.common" version="0.0.0"/>

--- a/org.eclipse.gef.mvc.fx-feature/feature.xml
+++ b/org.eclipse.gef.mvc.fx-feature/feature.xml
@@ -34,7 +34,6 @@
    <requires>
       <import plugin="com.google.guava" version="12.0.0" match="greaterOrEqual"/>
       <import plugin="com.google.inject" version="5.0.0" match="compatible"/>
-      <import plugin="javax.inject" version="1.0.0" match="compatible"/>
       <import feature="org.eclipse.gef.common" version="5.0.0" match="compatible"/>
       <import feature="org.eclipse.gef.geometry" version="5.0.0" match="compatible"/>
       <import feature="org.eclipse.gef.geometry.convert.fx" version="5.0.0" match="compatible"/>


### PR DESCRIPTION
This avoids pinning to a specific provider bundle of the `javax.inject` packages.

GEF is one of few remaining projects that still pull the `javax.inject` bundles originating from Orbit into the Eclipse SimRel and it would therefore be good to get rid of that strict requirement.
In general it is not necessary to duplicate the requirements of included Plugin in a Feature. It is better (and less work) to define the requirements with proper version ranges on the Plugin/Bundle-level.

Context: https://github.com/eclipse-simrel/simrel.build/pull/49