### PR TITLE
Update to build with latest dependencies

### DIFF
--- a/org.eclipse.gef.dot.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.dot.generator/META-INF/MANIFEST.MF
@@ -7,8 +7,9 @@ Bundle-Vendor: Eclipse GEF
 Bundle-Version: 5.1.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.core;bundle-version="[2.7.3,3.0.0)",
- org.eclipse.xtext;bundle-version="[2.7.3,3.0.0)",
- org.eclipse.xtext.generator;bundle-version="[2.7.3,3.0.0)"
+ org.eclipse.xtext;bundle-version="[2.7.3,3.0.0)"
 Export-Package: org.eclipse.gef.dot.internal.generator
+Import-Package: org.eclipse.xtext.xtext.generator,
+ org.eclipse.xtext.xtext.generator.model
 Bundle-ClassPath: .,
  xtext-generator-extensions.jar

--- a/org.eclipse.gef.dot/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.dot/META-INF/MANIFEST.MF
@@ -15,12 +15,7 @@ Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.xtext.util;bundle-version="[2.26.0,3.0.0)",
  org.eclipse.xtext.xbase.lib;bundle-version="[2.26.0,3.0.0)",
  org.eclipse.gef.common;bundle-version="[5.0.0,6.0.0)",
- org.eclipse.gef.graph;bundle-version="[5.0.0,6.0.0)",
- org.apache.commons.logging;bundle-version="[1.1.1,2.0.0)";resolution:=optional,
- org.eclipse.equinox.common;bundle-version="[3.6.0,4.0.0)";resolution:=optional,
- org.eclipse.emf.mwe2.launch;bundle-version="[2.12.0,3.0.0)";resolution:=optional,
- org.eclipse.xtext.generator;bundle-version="[2.26.0,3.0.0)";resolution:=optional,
- org.eclipse.gef.dot.generator;bundle-version="[5.0.0,6.0.0)";resolution:=optional
+ org.eclipse.gef.graph;bundle-version="[5.0.0,6.0.0)"
 Export-Package: org.eclipse.gef.dot.internal;x-friends:="org.eclipse.gef.dot.tests,org.eclipse.gef.dot.ui",
  org.eclipse.gef.dot.internal.language;x-friends:="org.eclipse.gef.dot.tests,org.eclipse.gef.dot.ui",
  org.eclipse.gef.dot.internal.language.arrowtype;x-friends:="org.eclipse.gef.dot.tests,org.eclipse.gef.dot.ui",

--- a/org.eclipse.gef.dot/build.properties
+++ b/org.eclipse.gef.dot/build.properties
@@ -25,3 +25,15 @@ bin.includes = model/generated/,\
                about.html,\
                gef_eclipse_logo_32.png
 src.includes = about.html
+additional.bundles = org.eclipse.equinox.common,\
+                     org.eclipse.xtext.xbase,\
+                     org.eclipse.xtext.common.types,\
+                     org.eclipse.xtext.xtext.generator,\
+                     org.eclipse.emf.codegen.ecore,\
+                     org.eclipse.emf.mwe.utils,\
+                     org.eclipse.emf.mwe2.launch,\
+                     org.eclipse.emf.mwe2.lib,\
+                     org.objectweb.asm,\
+                     org.apache.commons.logging,\
+                     org.apache.log4j,\
+                     org.eclipse.gef.dot.generator

--- a/org.eclipse.gef.releng/Jenkinsfile
+++ b/org.eclipse.gef.releng/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '10'))
     disableConcurrentBuilds()
     checkoutToSubdirectory('gef')
-    skipDefaultCheckout true
   }
 
   tools {
@@ -80,7 +79,7 @@ BRANCH_NAME=${env.BRANCH_NAME}
     stage('Git Checkout') {
       steps {
         script {
-          if (true) {
+          if (false) {
             def gitVariables = checkout(
               poll: false,
               scm: [

--- a/org.eclipse.gef.target/2023-12.target
+++ b/org.eclipse.gef.target/2023-12.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from GEF" sequenceNumber="10">
+<target name="Generated from GEF" sequenceNumber="11">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="com.google.inject.assistedinject" version="0.0.0"/>
@@ -10,15 +10,14 @@
       <unit id="org.eclipse.fx.runtime.min.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.xtext.generator" version="0.0.0"/>
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/cbi/updates/license"/>
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
       <repository location="https://download.eclipse.org/efxclipse/runtime-released/3.9.0/site"/>
       <repository location="https://download.itemis.com/updates/releases/2.1.0"/>
       <repository location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/latest"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.32.0"/>
-      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.15.0"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.33.0"/>
+      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.16.0"/>
       <repository location="https://download.eclipse.org/eclipse/updates/4.30-I-builds"/>
     </location>
   </locations>


### PR DESCRIPTION
Use latest Xtext/MWE2 releases.
Improve how the MWE build dependencies are specified.

https://github.com/eclipse/gef/issues/108