### PR TITLE
Dispose the font for DotExportRadioGroupFieldEditor.getRadioBoxControl

### DIFF
--- a/org.eclipse.gef.dot.sdk-feature/feature.xml
+++ b/org.eclipse.gef.dot.sdk-feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gef.dot.sdk"
       label="GEF DOT SDK"
-      version="5.1.3.qualifier"
+      version="5.1.4.qualifier"
       provider-name="Eclipse GEF"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.v20181016-2210">

--- a/org.eclipse.gef.dot.sdk-feature/pom.xml
+++ b/org.eclipse.gef.dot.sdk-feature/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.features</groupId>
 	<artifactId>org.eclipse.gef.dot.sdk</artifactId>
-	<version>5.1.3-SNAPSHOT</version>
+	<version>5.1.4-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.gef.dot.ui-feature/feature.xml
+++ b/org.eclipse.gef.dot.ui-feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gef.dot.ui"
       label="GEF DOT.UI"
-      version="5.1.3.qualifier"
+      version="5.1.4.qualifier"
       provider-name="Eclipse GEF"
       plugin="org.eclipse.gef.dot.ui"
       license-feature="org.eclipse.license"

--- a/org.eclipse.gef.dot.ui-feature/pom.xml
+++ b/org.eclipse.gef.dot.ui-feature/pom.xml
@@ -22,6 +22,6 @@
 	</parent>
 	<groupId>org.eclipse.gef.features</groupId>
 	<artifactId>org.eclipse.gef.dot.ui</artifactId>
-	<version>5.1.3-SNAPSHOT</version>
+	<version>5.1.4-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 </project>

--- a/org.eclipse.gef.dot.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.gef.dot.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.gef.dot.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: GEF DOT.UI
 Bundle-SymbolicName: org.eclipse.gef.dot.ui;singleton:=true
-Bundle-Version: 5.1.4.qualifier
+Bundle-Version: 5.1.5.qualifier
 Bundle-Vendor: Eclipse GEF
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gef.dot.internal.ui;x-friends:="org.eclipse.gef.dot.tests",

--- a/org.eclipse.gef.dot.ui/pom.xml
+++ b/org.eclipse.gef.dot.ui/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.plugins</groupId>
 	<artifactId>org.eclipse.gef.dot.ui</artifactId>
-	<version>5.1.4-SNAPSHOT</version>
+	<version>5.1.5-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/preferences/DotExportRadioGroupFieldEditor.java
+++ b/org.eclipse.gef.dot.ui/src/org/eclipse/gef/dot/internal/ui/preferences/DotExportRadioGroupFieldEditor.java
@@ -239,6 +239,7 @@ public class DotExportRadioGroupFieldEditor extends RadioGroupFieldEditor {
 				public void widgetDisposed(DisposeEvent event) {
 					radioBox = null;
 					radioButtons = null;
+					boldFont.dispose();
 				}
 
 			});

--- a/org.eclipse.gef.dot.user-feature/feature.xml
+++ b/org.eclipse.gef.dot.user-feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gef.dot.user"
       label="GEF DOT End-User Tools"
-      version="5.1.3.qualifier"
+      version="5.1.4.qualifier"
       provider-name="Eclipse GEF"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.v20181016-2210">

--- a/org.eclipse.gef.dot.user-feature/pom.xml
+++ b/org.eclipse.gef.dot.user-feature/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.features</groupId>
 	<artifactId>org.eclipse.gef.dot.user</artifactId>
-	<version>5.1.3-SNAPSHOT</version>
+	<version>5.1.4-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	<build>
 		<plugins>

--- a/org.eclipse.gef.releng/pom.xml
+++ b/org.eclipse.gef.releng/pom.xml
@@ -25,7 +25,7 @@
 		<maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
 		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
 		<maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
-		<tycho.version>4.0.9</tycho.version>
+		<tycho.version>4.0.10</tycho.version>
 		<target-platform>2023-12</target-platform>
 		<cbi-plugins.version>1.5.0</cbi-plugins.version>
 		<exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>

--- a/org.eclipse.gef.sdk-feature/feature.xml
+++ b/org.eclipse.gef.sdk-feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gef.sdk"
       label="GEF SDK"
-      version="5.5.0.qualifier"
+      version="5.5.1.qualifier"
       provider-name="Eclipse GEF"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.v20181016-2210">

--- a/org.eclipse.gef.sdk-feature/pom.xml
+++ b/org.eclipse.gef.sdk-feature/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.gef.features</groupId>
 	<artifactId>org.eclipse.gef.sdk</artifactId>
-	<version>5.5.0-SNAPSHOT</version>
+	<version>5.5.1-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	<build>
 		<plugins>


### PR DESCRIPTION
- Increment the versions of affected bundles and feature
- Use Tycho 4.0.10

https://github.com/eclipse-gef/gef/issues/118